### PR TITLE
updated to latest OAS Zod Validator, and improved UI for errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+.yarn/install-state.gz
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+.env
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
+
+# pnpm
+.pnpm-store/
+
+# temporary files
+_tmp_*

--- a/dflight-uav-api.json
+++ b/dflight-uav-api.json
@@ -1,0 +1,8455 @@
+{
+  "openapi": "3.0.2",
+  "servers": [
+    {
+      "description": "DFlight API",
+      "url": "https://dflight-api.ljaero.com/"
+    }
+  ],
+  "info": {
+    "description": "[DFlight API](https://ljaero.com/solutions/dflight/) supplies the up-to-date information needed for compliance with UAV preflight assessment requirements. Separate endpoints are available for each of the following information categories:\n- Airspace\n- Weather\n- Temporary Flight Restrictions\n- Special Security Areas\n- Restricted Public Venues\n- Surface Obstacles\n- Aerodromes\n- UAS Operating Areas\n\nYou can define your geographic area of interest in one of three convenient ways:\n- Providing a latitude/longitude point and distance around that point\n- Providing a GeoJSON LineString defining your route\n- Providing an arbitrary GeoJSON Polygon defining your area of interest",
+    "title": "DFlight API",
+    "version": "V 1.0.0",
+    "x-logo": {
+      "url": "https://api.apis.guru/v2/cache/logo/https_0.gravatar.com_blavatar_653166773dc88127bd3afe0b6dfe5ea7.png"
+    },
+    "x-origin": [
+      {
+        "format": "openapi",
+        "url": "https://dflight-api.ljaero.com/openapi.json",
+        "version": "3.0"
+      }
+    ],
+    "x-providerName": "ljaero.com",
+    "x-serviceName": "dflight"
+  },
+  "tags": [
+    {
+      "description": "#### Information is available for the following types of airspace:\n* **Controlled Airspace (CAS):** Class B, C, D, E2 airspace names, boundaries, altitude information, and LAANC availability\n* **Special Use Airspace (SUA):** Names, boundaries, and altitude information for the following types of Special Use Airspace:\n    - Alert Areas (AA)\n    - Military Operations Areas (MOA)\n    - National Security Areas (NSA)\n    - Prohibited Areas (PA)\n    - Restricted Areas (RA)\n    - Warning Areas (WA)\n* **Miscellaneous Activity Areas (MAA):** Names and boundary information for the following types of Miscellaneous Activity Areas:\n    - Aerobatic Practice Areas (AEROBATIC PRACTICE)\n    - Glider Operations Areas (GLIDER)\n    - Hang Glider Operations Areas (HANG GLIDER)\n    - Parachute Jump Areas (PARACHUTE JUMP AREA)\n    - Space Launch Activity Areas (SPACE LAUNCH ACTIVITY)\n* **Military Training Routes (MTR):** Names, route geometry, usage times, and corridor width information for both VFR and IFR Military Training Routes",
+      "name": "Airspace"
+    },
+    {
+      "description": "#### Hourly forecast values for the following flight-impacting weather elements:\n* Cloud Ceiling (CIG)\n* Dewpoint Temperature (DEWPT)\n* Cloud Cover (SKY)\n* Air Temperature (TEMP)\n* Visibility (VIS)\n* Wind Direction (WINDDIR)\n* Wind Speed (WINDSPEED)\n* Wind Gust Speed (WINDGUST)",
+      "name": "Weather"
+    },
+    {
+      "description": "#### Temporary Flight Restrictions (TFRs) define areas restricting air operations (including drone operations) due to hazardous conditions, special events, or other safety/security reasons.\nAll published/active TFRs in specified area will be included in the response. Check the startDateTime and endDateTime properties to determine whether or not the restriction is applicable during your planned time of operation. In case of a TFR in your area of intended operation, you might still be able to fly by obtaining a via waiver through the [Special Governmental Interest (SGI) process](https://www.faa.gov/uas/advanced_operations/emergency_situations).",
+      "name": "Flight Restrictions"
+    },
+    {
+      "description": "#### Locations where all UAS flight operations are prohibited unless prior FAA authorization has been obtained, and coordination with the controlling agency has taken place.\nThrough agreements with the Department of Defense and other U.S. security and intelligence agencies, the FAA published these restrictions as [FDC NOTAM 1/0488](https://tfr.faa.gov/save_pages/detail_1_0488.html) (and it's predecessors). Unlike other NOTAMs designated as [Temporary Flight Restrictions](https://dflight-api.ljaero.com/#/Flight%20Restrictions), these remain in effect 24 hours a day, 7 days a week, until further announcement.",
+      "name": "Special Security Areas"
+    },
+    {
+      "description": "#### Areas where drone operations may be restricted or prohibited:\n* Lands administered by the National Park Service (prohibited at all times)\n* Major League Baseball Stadiums (prohibited within a 3 NM radius 1 hr before - 1 hr after game)\n* National Football League Stadiums (prohibited within a 3 NM radius 1 hr before - 1 hr after game)\n* NCAA Division One Football Stadiums (prohibited within a 3 NM radius 1 hr before - 1 hr after game)\n* NASCAR Sprint Cup, Indy Car, and Champ Series races (prohibited within a 3 NM radius 1 hr before - 1 hr after race)",
+      "name": "Restricted Public Venues"
+    },
+    {
+      "description": "#### All known structures whose presence might interfere with airborne activity, as defined in [14 CFR Part 77.9](https://www.ecfr.gov/current/title-14/chapter-I/subchapter-E/part-77#77.9).\nThis information is updated daily and includes the following details:\n* Location\n* Type\n* Number of separate structures in case of a group\n* Height (in ft. AGL)\n* Lighting and other markings",
+      "name": "Surface Obstacles"
+    },
+    {
+      "description": "#### Center points and contact information for all US landing facilities, including those with no associated controlled airspace:\n* Public and private airports\n* Public and private balloonports\n* Public and private gliderports\n* Public and private heliports\n* Public and private seaplane bases\n* Public and private ultralight bases",
+      "name": "Aerodromes"
+    },
+    {
+      "description": "#### Areas where drone activity is scheduled to take place. \nUAS Operating Areas (UOAs) are published via [NOTAM](https://www.faa.gov/regulations_policies/orders_notices/index.cfm/go/document.information/documentID/1035053) to alert airspace users of unmanned aircraft activity in a given area and at a given time (singular or recurring).",
+      "name": "UAS Operating Areas"
+    }
+  ],
+  "paths": {
+    "/us/v1/aerodromes/distance-query": {
+      "post": {
+        "description": "Retrieve aerodromes within given distance of a point. Request body parameters are:\n* latitude:  WGS84 latitude coordinate of your selected point, in decimal degrees\n* longitude:  WGS84 longitude coordinate of your selected point, in decimal degrees\n* distance:  distance in meters (max allowed value is 25000)\n\nSuccessful requests return a GeoJSON FeatureCollection, with a separate Feature for each\nAerodrome found. All Features will include properties for the facility name, ident,\ntype, and operational status.",
+        "operationId": "aerodromes_by_distance_us_v1_aerodromes_distance_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AerodromesByDistance"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AerodromeDistanceResponse"
+                }
+              }
+            },
+            "description": "A GeoJSON FeatureCollection, one Feature for each aerodrome found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve aerodromes within given distance of location.",
+        "tags": ["Aerodromes"]
+      }
+    },
+    "/us/v1/aerodromes/polygon-query": {
+      "post": {
+        "description": "Retrieve aerodromes located within given area. Request body parameters are:\n* poly:  [GeoJSON Polygon](https://www.rfc-editor.org/rfc/rfc7946.html#appendix-A) defining the area. Max allowed area is 1000 km^2.\n\nSuccessful requests return a GeoJSON FeatureCollection, with a separate Feature for each\nAerodrome found. All Features will include properties for the facility name, ident,\ntype, and operational status.",
+        "operationId": "aerodromes_by_poly_us_v1_aerodromes_polygon_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AerodromesByPolygon"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AerodromePolyResponse"
+                }
+              }
+            },
+            "description": "A GeoJSON FeatureCollection, one Feature for each aerodrome found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve aerodromes located within given area.",
+        "tags": ["Aerodromes"]
+      }
+    },
+    "/us/v1/aerodromes/route-query": {
+      "post": {
+        "description": "Retrieve aerodromes found along a route. Request body parameters are:\n* route: [GeoJSON Linestring](https://www.rfc-editor.org/rfc/rfc7946.html#appendix-A) defining the route. Max allowed length is 50 km.\n\nSuccessful requests return a GeoJSON FeatureCollection, with a separate Feature for each\nAerodrome found. All Features will include properties for the facility name, ident,\ntype, and operational status.",
+        "operationId": "aerodromes_by_route_us_v1_aerodromes_route_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AerodromesByRoute"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AerodromeRouteResponse"
+                }
+              }
+            },
+            "description": "A GeoJSON FeatureCollection, one Feature for each aerodrome found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve aerodromes found along a route.",
+        "tags": ["Aerodromes"]
+      }
+    },
+    "/us/v1/airspace/distance-query": {
+      "post": {
+        "description": "Retrieve selected types of airspace existing within given distance from a point. Request body parameters are:\n* latitude:  WGS84 latitude coordinate of your selected point, in decimal degrees\n* longitude:  WGS84 longitude coordinate of your selected point, in decimal degrees\n* distance:  distance in meters (max allowed value is 25000)\n* asptypes:  list of one or more airspace types you wish to retrieve. Allowed values are 'CAS', 'SUA', 'MAA', and 'MTR'.\n\nSuccessful requests return a list of GeoJSON FeatureCollections, one for each Airspace type indicated in the request. Within each feature collection, there will be a separate Feature for each Airspace instance found. All Features will include a property indicating the *airspace_type*. Additional properties for each *airspace_type* are as follows:\n* CAS (Controlled Airspace)\n    - *name*\n    - *cas_class*: B, C, D, or E2\n    - *floor*: integer value in ft MSL\n    - *ceiling*: integer value in ft MSL\n    - *lannc*: true/false indicating whether or not authorization for this airspace may be obtained via LAANC\n* SUA (Special Use Airspace)\n    - *name*\n    - *sua_type*: AA = Alert Area, MOA = Military Operations Area, NSA = National Security Area, PA = Prohibited Area, RA = Restricted Area, WA = Warning Area\n    - *floor*: lower limit of the airspace\n    - *floor_uom*: unit of measure used for the numeric floor value: FT (feet) or FL (flight level)\n    - *floor_ref*: reference level used for the numeric floor value: AGL, MSL, or STD (standard atmosphere, used for flight level values)\n    - *ceiling*: upper limit of the airspace\n    - *ceiling_uom*: unit of measure used for the numeric floor value: FT (feet) or FL (flight level)\n    - *ceiling_ref*: reference level used for the numeric ceiling value: AGL, MSL, or STD (standard atmosphere, used for flight level values)\n* MAA (Miscellaneous Activity Area)\n    - *name*\n    - *maa_type*: one of the following - ULTRALIGHT, PARACHUTE JUMP AREA, AEROBATIC PRACTICE, GLIDER, HANG GLIDER, SPACE LAUNCH ACTIVITY\n    - *use_times*: textual description of days/times when activity in the area should be expected\n* MTR (Military Training Route)\n    - *name*\n    - *use_times*: textual description of days/times when MTR is active/hot\n    - *terrain_following*: boolean value indicating whether terrain following activity occurs on the route\n    - *max_extent_nm*: maximum distance that aircraft can deviate from route centerline",
+        "operationId": "asp_by_distance_us_v1_airspace_distance_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AirspaceByDistance"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AirspaceDistanceResponse"
+                }
+              }
+            },
+            "description": "A list of GeoJSON FeatureCollections, one for each Airspace type requested."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve all requested types of airspace located within given distance of location.",
+        "tags": ["Airspace"]
+      }
+    },
+    "/us/v1/airspace/polygon-query": {
+      "post": {
+        "description": "Retrieve selected types of airspace located within given area. Request body parameters are:\n* poly:  [GeoJSON Polygon](https://www.rfc-editor.org/rfc/rfc7946.html#appendix-A) defining the area. Max allowed area is 1000 km^2.\n* asptypes:  list of one or more airspace types you wish to retrieve. Allowed values are 'CAS', 'SUA', 'MAA', and 'MTR'.\n\nSuccessful requests return a list of GeoJSON FeatureCollections, one for each Airspace type indicated in the request. Within each feature collection, there will be a separate Feature for each Airspace instance found. All Features will include a property indicating the *airspace_type*. Additional properties for each *airspace_type* are as follows:\n* CAS (Controlled Airspace)\n    - *name*\n    - *cas_class*: B, C, D, or E2\n    - *floor*: integer value in ft MSL\n    - *ceiling*: integer value in ft MSL\n    - *lannc*: true/false indicating whether or not authorization for this airspace may be obtained via LAANC\n* SUA (Special Use Airspace)\n    - *name*\n    - *sua_type*: AA = Alert Area, MOA = Military Operations Area, NSA = National Security Area, PA = Prohibited Area, RA = Restricted Area, WA = Warning Area\n    - *floor*: lower limit of the airspace\n    - *floor_uom*: unit of measure used for the numeric floor value: FT (feet) or FL (flight level)\n    - *floor_ref*: reference level used for the numeric floor value: AGL, MSL, or STD (standard atmosphere, used for flight level values)\n    - *ceiling*: upper limit of the airspace\n    - *ceiling_uom*: unit of measure used for the numeric floor value: FT (feet) or FL (flight level)\n    - *ceiling_ref*: reference level used for the numeric ceiling value: AGL, MSL, or STD (standard atmosphere, used for flight level values)\n* MAA (Miscellaneous Activity Area)\n    - *name*\n    - *maa_type*: one of the following - ULTRALIGHT, PARACHUTE JUMP AREA, AEROBATIC PRACTICE, GLIDER, HANG GLIDER, SPACE LAUNCH ACTIVITY\n    - *use_times*: textual description of days/times when activity in the area should be expected\n* MTR (Military Training Route)\n    - *name*\n    - *use_times*: textual description of days/times when MTR is active/hot\n    - *terrain_following*: boolean value indicating whether terrain following activity occurs on the route\n    - *max_extent_nm*: maximum distance that aircraft can deviate from route centerline",
+        "operationId": "asp_by_poly_us_v1_airspace_polygon_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AirspaceByPolygon"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AirspacePolyResponse"
+                }
+              }
+            },
+            "description": "A list of GeoJSON FeatureCollections, one for each Airspace type requested."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve all requested types of airspace located within given GeoJSON Polygon.",
+        "tags": ["Airspace"]
+      }
+    },
+    "/us/v1/airspace/route-query": {
+      "post": {
+        "description": "Retrieve selected types of airspace traversed by route. Request body parameters are:\n* route:  [GeoJSON Linestring](https://www.rfc-editor.org/rfc/rfc7946.html#appendix-A) defining the route. Max allowed length is 50 km.\n* asptypes:  list of one or more airspace types you wish to retrieve. Allowed values are 'CAS', 'SUA', 'MAA', and 'MTR'.\n\nSuccessful requests return a list of GeoJSON FeatureCollections, one for each Airspace type indicated in the request. Within each feature collection, there will be a separate Feature for each Airspace instance found. All Features will include a property indicating the *airspace_type*. Additional properties for each *airspace_type* are as follows:\n* CAS (Controlled Airspace)\n    - *name*\n    - *cas_class*: B, C, D, or E2\n    - *floor*: integer value in ft MSL\n    - *ceiling*: integer value in ft MSL\n    - *lannc*: true/false indicating whether or not authorization for this airspace may be obtained via LAANC\n* SUA (Special Use Airspace)\n    - *name*\n    - *sua_type*: AA = Alert Area, MOA = Military Operations Area, NSA = National Security Area, PA = Prohibited Area, RA = Restricted Area, WA = Warning Area\n    - *floor*: lower limit of the airspace\n    - *floor_uom*: unit of measure used for the numeric floor value: FT (feet) or FL (flight level)\n    - *floor_ref*: reference level used for the numeric floor value: AGL, MSL, or STD (standard atmosphere, used for flight level values)\n    - *ceiling*: upper limit of the airspace\n    - *ceiling_uom*: unit of measure used for the numeric floor value: FT (feet) or FL (flight level)\n    - *ceiling_ref*: reference level used for the numeric ceiling value: AGL, MSL, or STD (standard atmosphere, used for flight level values)\n* MAA (Miscellaneous Activity Area)\n    - *name*\n    - *maa_type*: one of the following - ULTRALIGHT, PARACHUTE JUMP AREA, AEROBATIC PRACTICE, GLIDER, HANG GLIDER, SPACE LAUNCH ACTIVITY\n    - *use_times*: textual description of days/times when activity in the area should be expected\n* MTR (Military Training Route)\n    - *name*\n    - *use_times*: textual description of days/times when MTR is active/hot\n    - *terrain_following*: boolean value indicating whether terrain following activity occurs on the route\n    - *max_extent_nm*: maximum distance that aircraft can deviate from route centerline",
+        "operationId": "asp_by_route_us_v1_airspace_route_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AirspaceByRoute"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AirspaceRouteResponse"
+                }
+              }
+            },
+            "description": "A list of GeoJSON FeatureCollections, one for each Airspace type requested."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve all requested types of airspace traversed by route.",
+        "tags": ["Airspace"]
+      }
+    },
+    "/us/v1/obstacles/distance-query": {
+      "post": {
+        "description": "Retrieve obstacles within given distance of a point. Request body parameters are:\n* latitude:  WGS84 latitude coordinate of your selected point, in decimal degrees\n* longitude:  WGS84 longitude coordinate of your selected point, in decimal degrees\n* distance:  distance in meters (max allowed value is 25000)",
+        "operationId": "obstacles_by_distance_us_v1_obstacles_distance_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ObstaclesByDistance"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ObstacleDistanceResponse"
+                }
+              }
+            },
+            "description": "A GeoJSON FeatureCollection, one Feature for each obstacle found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve obstacles within given distance of location.",
+        "tags": ["Surface Obstacles"]
+      }
+    },
+    "/us/v1/obstacles/polygon-query": {
+      "post": {
+        "description": "Retrieve obstacles located within given area. Request body parameters are:\n* poly:  [GeoJSON Polygon](https://www.rfc-editor.org/rfc/rfc7946.html#appendix-A) defining the area. Max allowed area is 1000 km^2.",
+        "operationId": "obstacles_by_poly_us_v1_obstacles_polygon_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ObstaclesByPolygon"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ObstaclePolyResponse"
+                }
+              }
+            },
+            "description": "A GeoJSON FeatureCollection, one Feature for each obstacle found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve obstacles located within given area.",
+        "tags": ["Surface Obstacles"]
+      }
+    },
+    "/us/v1/obstacles/route-query": {
+      "post": {
+        "description": "Retrieve obstacles found along a route. Request body parameters are:\n* route: [GeoJSON Linestring](https://www.rfc-editor.org/rfc/rfc7946.html#appendix-A) defining the route. Max allowed length is 50 km.",
+        "operationId": "obstacles_by_route_us_v1_obstacles_route_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ObstaclesByRoute"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ObstacleRouteResponse"
+                }
+              }
+            },
+            "description": "A GeoJSON FeatureCollection, one Feature for each obstacle found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve obstacles found along a route.",
+        "tags": ["Surface Obstacles"]
+      }
+    },
+    "/us/v1/restrictions/distance-query": {
+      "post": {
+        "description": "Retrieve Flight Restrictions applicable within given distance of a point. Request body parameters are:\n* latitude:  WGS84 latitude coordinate of your selected point, in decimal degrees\n* longitude:  WGS84 longitude coordinate of your selected point, in decimal degrees\n* distance:  distance in meters (max allowed value is 25000)",
+        "operationId": "tfr_by_distance_us_v1_restrictions_distance_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NOTAMsByDistance"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NOTAMsDistanceResponse"
+                }
+              }
+            },
+            "description": "A GeoJSON FeatureCollection, one Feature for each restriction."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve flight restrictions applicable within given distance of location.",
+        "tags": ["Flight Restrictions"]
+      }
+    },
+    "/us/v1/restrictions/polygon-query": {
+      "post": {
+        "description": "Retrieve Flight Restrictions located within given area. Request body parameters are:\n* poly:  [GeoJSON Polygon](https://www.rfc-editor.org/rfc/rfc7946.html#appendix-A) defining the area. Max allowed area is 1000 km^2.",
+        "operationId": "tfr_by_poly_us_v1_restrictions_polygon_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NOTAMsByPolygon"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NOTAMsPolyResponse"
+                }
+              }
+            },
+            "description": "A GeoJSON FeatureCollection, one Feature for each restriction."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve flight restrictions applicable within given area.",
+        "tags": ["Flight Restrictions"]
+      }
+    },
+    "/us/v1/restrictions/route-query": {
+      "post": {
+        "description": "Retrieve Flight Restrictions applicable along your route. Request body parameters are:\n* route:  [GeoJSON Linestring](https://www.rfc-editor.org/rfc/rfc7946.html#appendix-A) defining the route. Max allowed length is 50 km.",
+        "operationId": "tfr_by_route_us_v1_restrictions_route_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NOTAMsByRoute"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NOTAMsRouteResponse"
+                }
+              }
+            },
+            "description": "A GeoJSON FeatureCollection, one Feature for each restriction."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve flight restrictions applicable along route.",
+        "tags": ["Flight Restrictions"]
+      }
+    },
+    "/us/v1/ssa/distance-query": {
+      "post": {
+        "description": "Retrieve special security areas existing within given distance from a point. Request body parameters are:\n* latitude:  WGS84 latitude coordinate of your selected point, in decimal degrees\n* longitude:  WGS84 longitude coordinate of your selected point, in decimal degrees\n* distance:  distance in meters (max allowed value is 25000)",
+        "operationId": "ssa_by_distance_us_v1_ssa_distance_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SSAByDistance"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SSADistanceResponse"
+                }
+              }
+            },
+            "description": "A GeoJSON FeatureCollection, one Feature for each area found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve all special security areas located within given distance of location.",
+        "tags": ["Special Security Areas"]
+      }
+    },
+    "/us/v1/ssa/polygon-query": {
+      "post": {
+        "description": "Retrieve all special security areas located within given area. Request body parameters are:\n* poly:  [GeoJSON Polygon](https://www.rfc-editor.org/rfc/rfc7946.html#appendix-A) defining the area. Max allowed area is 1000 km^2.",
+        "operationId": "ssa_by_poly_us_v1_ssa_polygon_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SSAByPolygon"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SSAPolyResponse"
+                }
+              }
+            },
+            "description": "A GeoJSON FeatureCollection, one Feature for each area found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve all special security areas located within given GeoJSON Polygon.",
+        "tags": ["Special Security Areas"]
+      }
+    },
+    "/us/v1/ssa/route-query": {
+      "post": {
+        "description": "Retrieve all special security areas intersected by route. Request body parameters are:\n* route: [GeoJSON Linestring](https://www.rfc-editor.org/rfc/rfc7946.html#appendix-A) defining the route. Max allowed length is 50 km.",
+        "operationId": "ssa_by_route_us_v1_ssa_route_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SSAByRoute"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SSARouteResponse"
+                }
+              }
+            },
+            "description": "A GeoJSON FeatureCollection, one Feature for each area found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve all special security areas traversed by route.",
+        "tags": ["Special Security Areas"]
+      }
+    },
+    "/us/v1/uoa/distance-query": {
+      "post": {
+        "description": "Retrieve UAS Operating Areas (UOAs) found within given distance of a point. Request body parameters are:\n* latitude:  WGS84 latitude coordinate of your selected point, in decimal degrees\n* longitude:  WGS84 longitude coordinate of your selected point, in decimal degrees\n* distance:  distance in meters (max allowed value is 25000)",
+        "operationId": "uoa_by_distance_us_v1_uoa_distance_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UOAsByDistance"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UOAsDistanceResponse"
+                }
+              }
+            },
+            "description": "A GeoJSON FeatureCollection, one Feature for each UOA."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve UAS Operating Areas (UOAs) found within given distance of location.",
+        "tags": ["UAS Operating Areas"]
+      }
+    },
+    "/us/v1/uoa/polygon-query": {
+      "post": {
+        "description": "Retrieve UAS Operating Areas (UOAs) found within given area. Request body parameters are:\n* poly:  [GeoJSON Polygon](https://www.rfc-editor.org/rfc/rfc7946.html#appendix-A) defining the area. Max allowed area is 1000 km^2.",
+        "operationId": "uoa_by_poly_us_v1_uoa_polygon_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UOAsByPolygon"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UOAsPolyResponse"
+                }
+              }
+            },
+            "description": "A GeoJSON FeatureCollection, one Feature for each UOA."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve UAS Operating Areas (UOAs) found within given area.",
+        "tags": ["UAS Operating Areas"]
+      }
+    },
+    "/us/v1/uoa/route-query": {
+      "post": {
+        "description": "Retrieve UAS Operating Areas (UOAs) found along your route. Request body parameters are:\n* route:  [GeoJSON Linestring](https://www.rfc-editor.org/rfc/rfc7946.html#appendix-A) defining the route. Max allowed length is 50 km.",
+        "operationId": "uoa_by_route_us_v1_uoa_route_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UOAsByRoute"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UOAsRouteResponse"
+                }
+              }
+            },
+            "description": "A GeoJSON FeatureCollection, one Feature for each UOA."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve UAS Operating Areas (UOAs) found along route.",
+        "tags": ["UAS Operating Areas"]
+      }
+    },
+    "/us/v1/venues/distance-query": {
+      "post": {
+        "description": "Retrieve venues existing within given distance from a point. Request body parameters are:\n* latitude:  WGS84 latitude coordinate of your selected point, in decimal degrees\n* longitude:  WGS84 longitude coordinate of your selected point, in decimal degrees\n* distance:  distance in meters (max allowed value is 25000)",
+        "operationId": "ven_by_distance_us_v1_venues_distance_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VenuesByDistance"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VenueDistanceResponse"
+                }
+              }
+            },
+            "description": "A GeoJSON FeatureCollection, one Feature for each venue found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve all restricted public venues located within given distance of location.",
+        "tags": ["Restricted Public Venues"]
+      }
+    },
+    "/us/v1/venues/polygon-query": {
+      "post": {
+        "description": "Retrieve all restricted public venues located within given area. Request body parameters are:\n* poly:  [GeoJSON Polygon](https://www.rfc-editor.org/rfc/rfc7946.html#appendix-A) defining the area. Max allowed area is 1000 km^2.",
+        "operationId": "ven_by_poly_us_v1_venues_polygon_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VenuesByPolygon"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VenuePolyResponse"
+                }
+              }
+            },
+            "description": "A GeoJSON FeatureCollection, one Feature for each venue found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve all restricted public venues located within given GeoJSON Polygon.",
+        "tags": ["Restricted Public Venues"]
+      }
+    },
+    "/us/v1/venues/route-query": {
+      "post": {
+        "description": "Retrieve all restricted public venues intersected by route. Request body parameters are:\n* route: [GeoJSON Linestring](https://www.rfc-editor.org/rfc/rfc7946.html#appendix-A) defining the route. Max allowed length is 50 km.",
+        "operationId": "ven_by_route_us_v1_venues_route_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VenuesByRoute"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VenueRouteResponse"
+                }
+              }
+            },
+            "description": "A GeoJSON FeatureCollection, one Feature for each venue found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve all restricted public venues traversed by route.",
+        "tags": ["Restricted Public Venues"]
+      }
+    },
+    "/us/v1/wx-forecast/distance-query": {
+      "post": {
+        "description": "Retrieve forecast values for selected weather elements and time period. Request body parameters are:\n* latitude:  WGS84 latitude coordinate of your selected point, in decimal degrees\n* longitude:  WGS84 longitude coordinate of your selected point, in decimal degrees\n* distance:  distance in meters (max allowed value is 25000)\n* wxtypes:  list of one or more weather forecast elements you wish to retrieve. Allowed values are \"CIG\", \"DEWPT\", \"SKY\", \"TEMP\", \"VIS\", \"WINDDIR\", \"WINDGUST\", \"WINDSPEED\".\n* hours:  number of hourly forecasts to return (1-24). For current hour only you should enter value of 1. To also retrieve values for each of the next n hours, enter n.\n\n\nThe response will consist of a GeoJSON FeatureCollection with one Feature for each forecast location found within requested area,\nproperties of which will include an ordered list of forecast values for each requested weather element, for each requested hour. Units for each element are as follows:\n* CIG: meters AGL\n* DEWPT: degrees Celsius\n* SKY: % cloud cover\n* TEMP: degrees Celsius\n* VIS: meters\n* WINDDIR: degrees true\n* WINDGUST: meters/sec\n* WINDSPEED: meters/sec",
+        "operationId": "wx_by_distance_us_v1_wx_forecast_distance_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WxByDistance"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WxDistanceResponse"
+                }
+              }
+            },
+            "description": "A GeoJSON FeatureCollection with one Feature for each forecast location found within requested area."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve forecast values within given distance of location for all requested weather elements and time periods.",
+        "tags": ["Weather"]
+      }
+    },
+    "/us/v1/wx-forecast/polygon-query": {
+      "post": {
+        "description": "Retrieve forecast values located within given area for requested weather elements and time period. Request body parameters are:\n* poly:  [GeoJSON Polygon](https://www.rfc-editor.org/rfc/rfc7946.html#appendix-A) defining the area. Max allowed area is 1000 km^2.\n* wxtypes:  list of one or more weather forecast elements you wish to retrieve. Allowed values are \"CIG\", \"DEWPT\", \"SKY\", \"TEMP\", \"VIS\", \"WINDDIR\", \"WINDGUST\", \"WINDSPEED\".\n* hours:  number of hourly forecasts to return (1-24). For current hour only you should enter value of 1. To also retrieve values for each of the next n hours, enter n.\n\n\nThe response will consist of a GeoJSON FeatureCollection with one Feature for each forecast location found within requested area,\nproperties of which will include an ordered list of forecast values for each requested weather element, for each requested hour. Units for each element are as follows:\n* CIG: meters AGL\n* DEWPT: degrees Celsius\n* SKY: % cloud cover\n* TEMP: degrees Celsius\n* VIS: meters\n* WINDDIR: degrees true\n* WINDGUST: meters/sec\n* WINDSPEED: meters/sec",
+        "operationId": "wx_by_poly_us_v1_wx_forecast_polygon_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WxByPolygon"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WxPolyResponse"
+                }
+              }
+            },
+            "description": "A GeoJSON FeatureCollection with one Feature for each forecast location found within requested area."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve forecast values within given GeoJSON polygon for all requested weather elements and time periods.",
+        "tags": ["Weather"]
+      }
+    },
+    "/us/v1/wx-forecast/route-query": {
+      "post": {
+        "description": "Retrieve forecast values along route for requested weather elements and time period. Request body parameters are:\n* route:  [GeoJSON Linestring](https://www.rfc-editor.org/rfc/rfc7946.html#appendix-A) defining the route. Max allowed length is 50 km.\n* wxtypes:  list of one or more weather forecast elements you wish to retrieve. Allowed values are \"CIG\", \"DEWPT\", \"SKY\", \"TEMP\", \"VIS\", \"WINDDIR\", \"WINDGUST\", \"WINDSPEED\".\n* hours:  number of hourly forecasts to return (1-24). For current hour only you should enter value of 1. To also retrieve values for each of the next n hours, enter n.\n\n\nThe response will consist of a GeoJSON FeatureCollection with one Feature for each forecast location found within requested area,\nproperties of which will include an ordered list of forecast values for each requested weather element, for each requested hour. Units for each element are as follows:\n* CIG: meters AGL\n* DEWPT: degrees Celsius\n* SKY: % cloud cover\n* TEMP: degrees Celsius\n* VIS: meters\n* WINDDIR: degrees true\n* WINDGUST: meters/sec\n* WINDSPEED: meters/sec",
+        "operationId": "wx_by_route_us_v1_wx_forecast_route_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WxByRoute"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WxRouteResponse"
+                }
+              }
+            },
+            "description": "A GeoJSON FeatureCollection with one Feature for each forecast location found within requested area."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve forecast values along a route for all requested weather elements and time periods.",
+        "tags": ["Weather"]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AerodromeDistanceResponse": {
+        "example": {
+          "found": {
+            "features": [
+              {
+                "geometry": {
+                  "coordinates": [-82.997126, 39.95534],
+                  "type": "Point"
+                },
+                "properties": {
+                  "contact_person": "Steve Skilken - Manager",
+                  "contact_phone": "614-221-4547",
+                  "facility_status": "OPERATIONAL",
+                  "facility_type": "PRIVATE HELIPORT",
+                  "ident": "5OH8",
+                  "name": "Joseph Skilken & Company"
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-82.962402, 39.97034],
+                  "type": "Point"
+                },
+                "properties": {
+                  "contact_person": "Ron Marstiller - Manager",
+                  "contact_phone": "614-257-2136",
+                  "facility_status": "OPERATIONAL",
+                  "facility_type": "PRIVATE HELIPORT",
+                  "ident": "2OI6",
+                  "name": "University Hospital East"
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-82.980154, 39.952685],
+                  "type": "Point"
+                },
+                "properties": {
+                  "contact_person": "Chip Henderson - Manager",
+                  "contact_phone": "614-722-6226",
+                  "facility_status": "OPERATIONAL",
+                  "facility_type": "PRIVATE HELIPORT",
+                  "ident": "OI95",
+                  "name": "Nationwide Children'S Hospital"
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-82.999348, 39.962562],
+                  "type": "Point"
+                },
+                "properties": {
+                  "contact_person": "Das Facility Manager - Manager",
+                  "contact_phone": "614-995-7751",
+                  "facility_status": "OPERATIONAL",
+                  "facility_type": "PRIVATE HELIPORT",
+                  "ident": "OH53",
+                  "name": "Ohio Bldg Authority"
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-82.991474, 39.960582],
+                  "type": "Point"
+                },
+                "properties": {
+                  "contact_person": "Gregory D Maney - Manager",
+                  "contact_phone": "614-566-9000",
+                  "facility_status": "OPERATIONAL",
+                  "facility_type": "PRIVATE HELIPORT",
+                  "ident": "OH01",
+                  "name": "Grant Medical Center"
+                },
+                "type": "Feature"
+              }
+            ],
+            "type": "FeatureCollection"
+          }
+        },
+        "properties": {
+          "found": {
+            "title": "Found",
+            "type": "object"
+          }
+        },
+        "required": ["found"],
+        "title": "AerodromeDistanceResponse",
+        "type": "object"
+      },
+      "AerodromePolyResponse": {
+        "example": {
+          "found": {
+            "features": [
+              {
+                "geometry": {
+                  "coordinates": [-122.348709, 47.619571],
+                  "type": "Point"
+                },
+                "properties": {
+                  "contact_person": "Keith Nealey - Manager",
+                  "contact_phone": "206-728-7777",
+                  "facility_status": "OPERATIONAL",
+                  "facility_type": "PRIVATE HELIPORT",
+                  "ident": "8WA9",
+                  "name": "Broadcast House Helistop"
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-122.344721, 47.621668],
+                  "type": "Point"
+                },
+                "properties": {
+                  "contact_person": "Jeff Pace - Manager",
+                  "contact_phone": "206-404-8000",
+                  "facility_status": "OPERATIONAL",
+                  "facility_type": "PRIVATE HELIPORT",
+                  "ident": "WN16",
+                  "name": "Komo Tv"
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-122.342347, 47.621489],
+                  "type": "Point"
+                },
+                "properties": {
+                  "contact_person": "Mark S. Hansen - Manager",
+                  "contact_phone": "206-448-3863",
+                  "facility_status": "OPERATIONAL",
+                  "facility_type": "PRIVATE HELIPORT",
+                  "ident": "WN01",
+                  "name": "Seattle Private Number One"
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-122.338736, 47.628989],
+                  "type": "Point"
+                },
+                "properties": {
+                  "contact_person": "Sarah Feller - Manager",
+                  "contact_phone": "425-486-1257",
+                  "facility_status": "OPERATIONAL",
+                  "facility_type": "PUBLIC SEAPLANE BASE",
+                  "ident": "W55",
+                  "name": "Kenmore Air Harbor"
+                },
+                "type": "Feature"
+              }
+            ],
+            "type": "FeatureCollection"
+          }
+        },
+        "properties": {
+          "found": {
+            "title": "Found",
+            "type": "object"
+          }
+        },
+        "required": ["found"],
+        "title": "AerodromePolyResponse",
+        "type": "object"
+      },
+      "AerodromeRouteResponse": {
+        "example": {
+          "found": {
+            "features": [
+              {
+                "geometry": {
+                  "coordinates": [-89.353022, 29.258748],
+                  "type": "Point"
+                },
+                "properties": {
+                  "contact_person": "Mickey Bull - Manager",
+                  "contact_phone": "504-465-3220",
+                  "facility_status": "OPERATIONAL",
+                  "facility_type": "PRIVATE SEAPLANE BASE",
+                  "ident": "11LA",
+                  "name": "Tiger Pass"
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-89.355051, 29.259386],
+                  "type": "Point"
+                },
+                "properties": {
+                  "contact_person": "H. A. Niehaus - Manager",
+                  "contact_phone": "504-368-3000",
+                  "facility_status": "OPERATIONAL",
+                  "facility_type": "PRIVATE HELIPORT",
+                  "ident": "8LA4",
+                  "name": "Conoco Inc Venice"
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-89.367829, 29.287441],
+                  "type": "Point"
+                },
+                "properties": {
+                  "contact_person": "Unknown",
+                  "contact_phone": "Unknown",
+                  "facility_status": "OPERATIONAL",
+                  "facility_type": "PRIVATE HELIPORT",
+                  "ident": "LS52",
+                  "name": "Era Helicopters Venice Base"
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-89.36394, 29.286052],
+                  "type": "Point"
+                },
+                "properties": {
+                  "contact_person": "R. J. Barnwell - Manager",
+                  "contact_phone": "318-233-8240",
+                  "facility_status": "OPERATIONAL",
+                  "facility_type": "PRIVATE HELIPORT",
+                  "ident": "LA47",
+                  "name": "Marathon Venice"
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-89.371108, 29.295554],
+                  "type": "Point"
+                },
+                "properties": {
+                  "contact_person": "Robert Old - Manager",
+                  "contact_phone": "(985) 288-1255",
+                  "facility_status": "OPERATIONAL",
+                  "facility_type": "PRIVATE HELIPORT",
+                  "ident": "45LA",
+                  "name": "Bristow Us Llc"
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-89.355831, 29.271109],
+                  "type": "Point"
+                },
+                "properties": {
+                  "contact_person": "Wayland Lewis - Manager",
+                  "contact_phone": "504-534-7031",
+                  "facility_status": "OPERATIONAL",
+                  "facility_type": "PRIVATE SEAPLANE BASE",
+                  "ident": "30LA",
+                  "name": "Venice Base Heliport & Spb"
+                },
+                "type": "Feature"
+              }
+            ],
+            "type": "FeatureCollection"
+          }
+        },
+        "properties": {
+          "found": {
+            "title": "Found",
+            "type": "object"
+          }
+        },
+        "required": ["found"],
+        "title": "AerodromeRouteResponse",
+        "type": "object"
+      },
+      "AerodromesByDistance": {
+        "description": "Geometry-defining arguments for point/distance requests",
+        "example": {
+          "distance": 5000,
+          "latitude": 39.94,
+          "longitude": -82.97
+        },
+        "properties": {
+          "distance": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Distance"
+          },
+          "latitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Latitude"
+          },
+          "longitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Longitude"
+          }
+        },
+        "required": ["longitude", "latitude", "distance"],
+        "title": "AerodromesByDistance",
+        "type": "object"
+      },
+      "AerodromesByPolygon": {
+        "description": "Geometry-defining arguments for polygon requests",
+        "example": {
+          "poly": {
+            "coordinates": [
+              [
+                [-122.338707447052, 47.62958028571895],
+                [-122.35679626464844, 47.61773556745509],
+                [-122.33343388885261, 47.61953540719045],
+                [-122.338707447052, 47.62958028571895]
+              ]
+            ],
+            "type": "Polygon"
+          }
+        },
+        "properties": {
+          "poly": {
+            "title": "Poly",
+            "type": "object"
+          }
+        },
+        "required": ["poly"],
+        "title": "AerodromesByPolygon",
+        "type": "object"
+      },
+      "AerodromesByRoute": {
+        "description": "Geometry-defining arguments for along-route requests",
+        "example": {
+          "route": {
+            "coordinates": [
+              [-89.353316, 29.270685],
+              [-89.36921, 29.290526],
+              [-89.376006, 29.298966]
+            ],
+            "type": "LineString"
+          }
+        },
+        "properties": {
+          "route": {
+            "title": "Route",
+            "type": "object"
+          }
+        },
+        "required": ["route"],
+        "title": "AerodromesByRoute",
+        "type": "object"
+      },
+      "AirspaceByDistance": {
+        "description": "Geometry-defining arguments for point/distance requests",
+        "example": {
+          "asptypes": ["MAA", "MTR"],
+          "distance": 5000,
+          "latitude": 44.6031,
+          "longitude": -88.2188
+        },
+        "properties": {
+          "asptypes": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Asptypes",
+            "type": "array"
+          },
+          "distance": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Distance"
+          },
+          "latitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Latitude"
+          },
+          "longitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Longitude"
+          }
+        },
+        "required": ["longitude", "latitude", "distance", "asptypes"],
+        "title": "AirspaceByDistance",
+        "type": "object"
+      },
+      "AirspaceByPolygon": {
+        "description": "Geometry-defining arguments for polygon requests",
+        "example": {
+          "asptypes": ["CAS"],
+          "poly": {
+            "coordinates": [
+              [
+                [-86.337, 41.716],
+                [-86.323, 41.718],
+                [-86.327, 41.727],
+                [-86.337, 41.722],
+                [-86.337, 41.716]
+              ]
+            ],
+            "type": "Polygon"
+          }
+        },
+        "properties": {
+          "asptypes": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Asptypes",
+            "type": "array"
+          },
+          "poly": {
+            "title": "Poly",
+            "type": "object"
+          }
+        },
+        "required": ["poly", "asptypes"],
+        "title": "AirspaceByPolygon",
+        "type": "object"
+      },
+      "AirspaceByRoute": {
+        "description": "Geometry-defining arguments for along-route requests",
+        "example": {
+          "asptypes": ["SUA", "MAA"],
+          "route": {
+            "coordinates": [
+              [-87.43633, 36.637119],
+              [-87.430424, 36.615407],
+              [-87.417378, 36.592697]
+            ],
+            "type": "LineString"
+          }
+        },
+        "properties": {
+          "asptypes": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Asptypes",
+            "type": "array"
+          },
+          "route": {
+            "title": "Route",
+            "type": "object"
+          }
+        },
+        "required": ["route", "asptypes"],
+        "title": "AirspaceByRoute",
+        "type": "object"
+      },
+      "AirspaceDistanceResponse": {
+        "example": {
+          "found": [
+            {
+              "features": [
+                {
+                  "geometry": {
+                    "coordinates": [
+                      [
+                        [-88.196474, 44.637461],
+                        [-88.196554, 44.636301],
+                        [-88.196794, 44.635151],
+                        [-88.197191, 44.634024],
+                        [-88.197741, 44.63293],
+                        [-88.198439, 44.63188],
+                        [-88.199278, 44.630884],
+                        [-88.200251, 44.62995],
+                        [-88.201347, 44.629089],
+                        [-88.202557, 44.628309],
+                        [-88.203868, 44.627617],
+                        [-88.205268, 44.62702],
+                        [-88.206744, 44.626523],
+                        [-88.208282, 44.626131],
+                        [-88.209865, 44.625849],
+                        [-88.21148, 44.625679],
+                        [-88.213111, 44.625622],
+                        [-88.214742, 44.625679],
+                        [-88.216357, 44.625849],
+                        [-88.21794, 44.626131],
+                        [-88.219478, 44.626523],
+                        [-88.220954, 44.62702],
+                        [-88.222354, 44.627617],
+                        [-88.223665, 44.628309],
+                        [-88.224875, 44.629089],
+                        [-88.225971, 44.62995],
+                        [-88.226944, 44.630884],
+                        [-88.227783, 44.63188],
+                        [-88.228481, 44.63293],
+                        [-88.229031, 44.634024],
+                        [-88.229428, 44.635151],
+                        [-88.229668, 44.636301],
+                        [-88.229748, 44.637461],
+                        [-88.229668, 44.638621],
+                        [-88.229428, 44.63977],
+                        [-88.229031, 44.640897],
+                        [-88.228481, 44.641991],
+                        [-88.227783, 44.643041],
+                        [-88.226944, 44.644038],
+                        [-88.225971, 44.644971],
+                        [-88.224875, 44.645831],
+                        [-88.223665, 44.646611],
+                        [-88.222354, 44.647303],
+                        [-88.220954, 44.6479],
+                        [-88.219478, 44.648397],
+                        [-88.21794, 44.648788],
+                        [-88.216357, 44.649071],
+                        [-88.214742, 44.649241],
+                        [-88.213111, 44.649298],
+                        [-88.21148, 44.649241],
+                        [-88.209865, 44.649071],
+                        [-88.208282, 44.648788],
+                        [-88.206744, 44.648397],
+                        [-88.205268, 44.6479],
+                        [-88.203868, 44.647303],
+                        [-88.202557, 44.646611],
+                        [-88.201347, 44.645831],
+                        [-88.200251, 44.644971],
+                        [-88.199278, 44.644038],
+                        [-88.198439, 44.643041],
+                        [-88.197741, 44.641991],
+                        [-88.197191, 44.640897],
+                        [-88.196794, 44.63977],
+                        [-88.196554, 44.638621],
+                        [-88.196474, 44.637461]
+                      ]
+                    ],
+                    "type": "Polygon"
+                  },
+                  "properties": {
+                    "airspace_type": "MAA",
+                    "maa_type": "PARACHUTE JUMP AREA",
+                    "name": "PWI007",
+                    "use_times": "DAILY SR-SS"
+                  },
+                  "type": "Feature"
+                }
+              ],
+              "type": "FeatureCollection"
+            },
+            {
+              "features": [
+                {
+                  "geometry": {
+                    "coordinates": [
+                      [-89.108332, 44.578334],
+                      [-89.283332, 44.755],
+                      [-89.566666, 44.890001],
+                      [-89.9, 44.888334],
+                      [-88.058335, 44.556668],
+                      [-89.936666, 44.450001],
+                      [-89.916666, 44.233334]
+                    ],
+                    "type": "LineString"
+                  },
+                  "properties": {
+                    "airspace_type": "MTR",
+                    "max_extent_nm": 4,
+                    "name": "1650VR",
+                    "terrain_following": true,
+                    "use_times": "0730 LOCAL-SUNSET TUE-SAT, OT BY NOTAM"
+                  },
+                  "type": "Feature"
+                }
+              ],
+              "type": "FeatureCollection"
+            }
+          ]
+        },
+        "properties": {
+          "found": {
+            "items": {
+              "type": "object"
+            },
+            "title": "Found",
+            "type": "array"
+          }
+        },
+        "required": ["found"],
+        "title": "AirspaceDistanceResponse",
+        "type": "object"
+      },
+      "AirspacePolyResponse": {
+        "example": {
+          "found": [
+            {
+              "features": [
+                {
+                  "geometry": {
+                    "coordinates": [
+                      [
+                        [-86.213003, 41.67939],
+                        [-86.213828, 41.677706],
+                        [-86.214701, 41.676035],
+                        [-86.215622, 41.674379],
+                        [-86.216591, 41.672738],
+                        [-86.217606, 41.671113],
+                        [-86.218668, 41.669505],
+                        [-86.219775, 41.667914],
+                        [-86.220928, 41.666342],
+                        [-86.222126, 41.664788],
+                        [-86.223368, 41.663254],
+                        [-86.224654, 41.661741],
+                        [-86.225982, 41.660248],
+                        [-86.227354, 41.658778],
+                        [-86.228767, 41.65733],
+                        [-86.230221, 41.655905],
+                        [-86.231716, 41.654504],
+                        [-86.233251, 41.653127],
+                        [-86.234825, 41.651775],
+                        [-86.236437, 41.650449],
+                        [-86.238087, 41.64915],
+                        [-86.239773, 41.647877],
+                        [-86.241496, 41.646632],
+                        [-86.243254, 41.645415],
+                        [-86.245047, 41.644227],
+                        [-86.246873, 41.643068],
+                        [-86.248732, 41.641938],
+                        [-86.250623, 41.640839],
+                        [-86.252545, 41.639771],
+                        [-86.254497, 41.638733],
+                        [-86.256478, 41.637728],
+                        [-86.258488, 41.636755],
+                        [-86.260525, 41.635814],
+                        [-86.262589, 41.634907],
+                        [-86.264678, 41.634033],
+                        [-86.266791, 41.633193],
+                        [-86.268929, 41.632387],
+                        [-86.271089, 41.631616],
+                        [-86.27327, 41.63088],
+                        [-86.275472, 41.63018],
+                        [-86.277693, 41.629515],
+                        [-86.279933, 41.628886],
+                        [-86.282191, 41.628293],
+                        [-86.284465, 41.627737],
+                        [-86.286754, 41.627218],
+                        [-86.289058, 41.626736],
+                        [-86.291375, 41.626291],
+                        [-86.293704, 41.625884],
+                        [-86.296045, 41.625514],
+                        [-86.298395, 41.625182],
+                        [-86.300754, 41.624889],
+                        [-86.303121, 41.624633],
+                        [-86.305495, 41.624416],
+                        [-86.307875, 41.624237],
+                        [-86.310259, 41.624096],
+                        [-86.312647, 41.623994],
+                        [-86.315037, 41.62393],
+                        [-86.317428, 41.623905],
+                        [-86.31982, 41.623919],
+                        [-86.32221, 41.623971],
+                        [-86.324599, 41.624062],
+                        [-86.326984, 41.624192],
+                        [-86.329365, 41.624359],
+                        [-86.331741, 41.624566],
+                        [-86.33411, 41.62481],
+                        [-86.336472, 41.625093],
+                        [-86.338825, 41.625414],
+                        [-86.341168, 41.625772],
+                        [-86.343501, 41.626169],
+                        [-86.345821, 41.626603],
+                        [-86.348129, 41.627074],
+                        [-86.350423, 41.627582],
+                        [-86.352701, 41.628128],
+                        [-86.354964, 41.62871],
+                        [-86.357215, 41.629316],
+                        [-86.335687, 41.653205],
+                        [-86.334459, 41.654687],
+                        [-86.33348, 41.656271],
+                        [-86.332726, 41.657924],
+                        [-86.332206, 41.659626],
+                        [-86.331926, 41.66136],
+                        [-86.331888, 41.663106],
+                        [-86.332094, 41.664846],
+                        [-86.332541, 41.66656],
+                        [-86.333224, 41.66823],
+                        [-86.334135, 41.669837],
+                        [-86.335265, 41.671364],
+                        [-86.336602, 41.672794],
+                        [-86.33813, 41.674112],
+                        [-86.339834, 41.675304],
+                        [-86.341694, 41.676355],
+                        [-86.34369, 41.677255],
+                        [-86.345801, 41.677994],
+                        [-86.348003, 41.678564],
+                        [-86.350272, 41.678958],
+                        [-86.352584, 41.679173],
+                        [-86.354913, 41.679206],
+                        [-86.357234, 41.679056],
+                        [-86.359522, 41.678726],
+                        [-86.361751, 41.678218],
+                        [-86.363897, 41.677539],
+                        [-86.365937, 41.676695],
+                        [-86.367848, 41.675697],
+                        [-86.36961, 41.674554],
+                        [-86.371203, 41.67328],
+                        [-86.37261, 41.671888],
+                        [-86.394804, 41.647166],
+                        [-86.396512, 41.648423],
+                        [-86.398182, 41.649707],
+                        [-86.399816, 41.651018],
+                        [-86.401412, 41.652355],
+                        [-86.402969, 41.653718],
+                        [-86.404486, 41.655105],
+                        [-86.405964, 41.656517],
+                        [-86.407401, 41.657952],
+                        [-86.408796, 41.659409],
+                        [-86.410149, 41.66089],
+                        [-86.411459, 41.662391],
+                        [-86.412726, 41.663913],
+                        [-86.413949, 41.665456],
+                        [-86.415128, 41.667018],
+                        [-86.416261, 41.668598],
+                        [-86.417349, 41.670196],
+                        [-86.41839, 41.671812],
+                        [-86.419386, 41.673444],
+                        [-86.420334, 41.675092],
+                        [-86.421234, 41.676754],
+                        [-86.422087, 41.678431],
+                        [-86.422891, 41.680121],
+                        [-86.423646, 41.681824],
+                        [-86.424353, 41.683538],
+                        [-86.42501, 41.685264],
+                        [-86.425618, 41.687],
+                        [-86.426175, 41.688745],
+                        [-86.426683, 41.690499],
+                        [-86.42714, 41.69226],
+                        [-86.427546, 41.694029],
+                        [-86.427901, 41.695803],
+                        [-86.428205, 41.697583],
+                        [-86.428458, 41.699368],
+                        [-86.428659, 41.701156],
+                        [-86.42881, 41.702947],
+                        [-86.428908, 41.70474],
+                        [-86.428955, 41.706534],
+                        [-86.428951, 41.708328],
+                        [-86.428895, 41.710122],
+                        [-86.428787, 41.711915],
+                        [-86.428628, 41.713705],
+                        [-86.428418, 41.715493],
+                        [-86.428156, 41.717276],
+                        [-86.427843, 41.719055],
+                        [-86.427479, 41.720829],
+                        [-86.427063, 41.722596],
+                        [-86.426598, 41.724356],
+                        [-86.426081, 41.726109],
+                        [-86.425515, 41.727852],
+                        [-86.424898, 41.729586],
+                        [-86.424232, 41.73131],
+                        [-86.423516, 41.733022],
+                        [-86.422751, 41.734723],
+                        [-86.421937, 41.73641],
+                        [-86.421075, 41.738085],
+                        [-86.420165, 41.739744],
+                        [-86.419207, 41.741389],
+                        [-86.418202, 41.743018],
+                        [-86.417151, 41.744631],
+                        [-86.416053, 41.746226],
+                        [-86.41491, 41.747803],
+                        [-86.413722, 41.749361],
+                        [-86.412489, 41.7509],
+                        [-86.411212, 41.752418],
+                        [-86.409891, 41.753915],
+                        [-86.408528, 41.755391],
+                        [-86.407122, 41.756845],
+                        [-86.405675, 41.758275],
+                        [-86.404187, 41.759682],
+                        [-86.402659, 41.761064],
+                        [-86.401092, 41.762421],
+                        [-86.399485, 41.763753],
+                        [-86.397841, 41.765059],
+                        [-86.39616, 41.766337],
+                        [-86.394442, 41.767589],
+                        [-86.392688, 41.768812],
+                        [-86.390899, 41.770006],
+                        [-86.389077, 41.771172],
+                        [-86.387221, 41.772308],
+                        [-86.385333, 41.773413],
+                        [-86.383414, 41.774488],
+                        [-86.381464, 41.775532],
+                        [-86.379484, 41.776544],
+                        [-86.377476, 41.777524],
+                        [-86.37544, 41.778471],
+                        [-86.373377, 41.779385],
+                        [-86.371288, 41.780265],
+                        [-86.369174, 41.781112],
+                        [-86.367036, 41.781924],
+                        [-86.364876, 41.782702],
+                        [-86.362693, 41.783445],
+                        [-86.36049, 41.784152],
+                        [-86.358266, 41.784823],
+                        [-86.356024, 41.785459],
+                        [-86.353764, 41.786058],
+                        [-86.351487, 41.78662],
+                        [-86.349195, 41.787146],
+                        [-86.346888, 41.787634],
+                        [-86.344567, 41.788085],
+                        [-86.342234, 41.788499],
+                        [-86.33989, 41.788875],
+                        [-86.337535, 41.789213],
+                        [-86.335171, 41.789512],
+                        [-86.332799, 41.789774],
+                        [-86.33042, 41.789997],
+                        [-86.328035, 41.790182],
+                        [-86.325645, 41.790328],
+                        [-86.323252, 41.790436],
+                        [-86.320856, 41.790505],
+                        [-86.318458, 41.790535],
+                        [-86.316061, 41.790527],
+                        [-86.313664, 41.79048],
+                        [-86.311269, 41.790394],
+                        [-86.308877, 41.79027],
+                        [-86.306489, 41.790107],
+                        [-86.304107, 41.789906],
+                        [-86.30173, 41.789666],
+                        [-86.299362, 41.789388],
+                        [-86.297002, 41.789071],
+                        [-86.294651, 41.788717],
+                        [-86.292311, 41.788325],
+                        [-86.289984, 41.787895],
+                        [-86.287669, 41.787428],
+                        [-86.285368, 41.786923],
+                        [-86.283082, 41.786382],
+                        [-86.280812, 41.785804],
+                        [-86.27856, 41.785189],
+                        [-86.276326, 41.784538],
+                        [-86.274111, 41.783851],
+                        [-86.271916, 41.783128],
+                        [-86.269743, 41.782371],
+                        [-86.267592, 41.781578],
+                        [-86.265465, 41.780751],
+                        [-86.263362, 41.77989],
+                        [-86.261284, 41.778994],
+                        [-86.259232, 41.778066],
+                        [-86.257208, 41.777105],
+                        [-86.255212, 41.776111],
+                        [-86.253245, 41.775085],
+                        [-86.251308, 41.774028],
+                        [-86.249402, 41.77294],
+                        [-86.247528, 41.771821],
+                        [-86.245687, 41.770673],
+                        [-86.243879, 41.769495],
+                        [-86.242105, 41.768287],
+                        [-86.240367, 41.767052],
+                        [-86.238664, 41.765789],
+                        [-86.236999, 41.764499],
+                        [-86.235371, 41.763182],
+                        [-86.233781, 41.761839],
+                        [-86.232231, 41.760471],
+                        [-86.23072, 41.759078],
+                        [-86.229249, 41.757661],
+                        [-86.22782, 41.75622],
+                        [-86.226433, 41.754757],
+                        [-86.225088, 41.753272],
+                        [-86.223786, 41.751765],
+                        [-86.222528, 41.750238],
+                        [-86.221314, 41.748691],
+                        [-86.220145, 41.747125],
+                        [-86.219022, 41.74554],
+                        [-86.217944, 41.743937],
+                        [-86.216913, 41.742317],
+                        [-86.215928, 41.740682],
+                        [-86.214991, 41.73903],
+                        [-86.214102, 41.737364],
+                        [-86.21326, 41.735684],
+                        [-86.212468, 41.73399],
+                        [-86.211724, 41.732285],
+                        [-86.211029, 41.730567],
+                        [-86.210384, 41.728839],
+                        [-86.209789, 41.727101],
+                        [-86.209244, 41.725354],
+                        [-86.20875, 41.723598],
+                        [-86.208306, 41.721835],
+                        [-86.207912, 41.720064],
+                        [-86.20757, 41.718288],
+                        [-86.207279, 41.716507],
+                        [-86.20704, 41.714722],
+                        [-86.206851, 41.712933],
+                        [-86.206714, 41.711142],
+                        [-86.206629, 41.709348],
+                        [-86.206595, 41.707554],
+                        [-86.206613, 41.70576],
+                        [-86.206682, 41.703966],
+                        [-86.206803, 41.702174],
+                        [-86.206976, 41.700384],
+                        [-86.207199, 41.698597],
+                        [-86.207474, 41.696815],
+                        [-86.207801, 41.695037],
+                        [-86.208178, 41.693265],
+                        [-86.208606, 41.6915],
+                        [-86.209083, 41.689741],
+                        [-86.209612, 41.687991],
+                        [-86.210191, 41.68625],
+                        [-86.21082, 41.684518],
+                        [-86.211499, 41.682797],
+                        [-86.212226, 41.681088],
+                        [-86.213003, 41.67939]
+                      ]
+                    ],
+                    "type": "Polygon"
+                  },
+                  "properties": {
+                    "airspace_type": "CAS",
+                    "cas_class": "C",
+                    "ceiling": 4800,
+                    "floor": 0,
+                    "laanc": true,
+                    "name": "SOUTH BEND, MICHIANA REGIONAL AIRPORT CLASS C"
+                  },
+                  "type": "Feature"
+                },
+                {
+                  "geometry": {
+                    "coordinates": [
+                      [
+                        [-86.213003, 41.67939],
+                        [-86.213828, 41.677706],
+                        [-86.214701, 41.676035],
+                        [-86.215622, 41.674379],
+                        [-86.216591, 41.672738],
+                        [-86.217606, 41.671113],
+                        [-86.218668, 41.669505],
+                        [-86.219775, 41.667914],
+                        [-86.220928, 41.666342],
+                        [-86.222126, 41.664788],
+                        [-86.223368, 41.663254],
+                        [-86.224654, 41.661741],
+                        [-86.225982, 41.660248],
+                        [-86.227354, 41.658778],
+                        [-86.228767, 41.65733],
+                        [-86.230221, 41.655905],
+                        [-86.231716, 41.654504],
+                        [-86.233251, 41.653127],
+                        [-86.234825, 41.651775],
+                        [-86.236437, 41.650449],
+                        [-86.238087, 41.64915],
+                        [-86.239773, 41.647877],
+                        [-86.241496, 41.646632],
+                        [-86.243254, 41.645415],
+                        [-86.245047, 41.644227],
+                        [-86.246873, 41.643068],
+                        [-86.248732, 41.641938],
+                        [-86.250623, 41.640839],
+                        [-86.252545, 41.639771],
+                        [-86.254497, 41.638733],
+                        [-86.256478, 41.637728],
+                        [-86.258488, 41.636755],
+                        [-86.260525, 41.635814],
+                        [-86.262589, 41.634907],
+                        [-86.264678, 41.634033],
+                        [-86.266791, 41.633193],
+                        [-86.268929, 41.632387],
+                        [-86.271089, 41.631616],
+                        [-86.27327, 41.63088],
+                        [-86.275472, 41.63018],
+                        [-86.277693, 41.629515],
+                        [-86.279933, 41.628886],
+                        [-86.282191, 41.628293],
+                        [-86.284465, 41.627737],
+                        [-86.286754, 41.627218],
+                        [-86.289058, 41.626736],
+                        [-86.291375, 41.626291],
+                        [-86.293704, 41.625884],
+                        [-86.296045, 41.625514],
+                        [-86.298395, 41.625182],
+                        [-86.300754, 41.624889],
+                        [-86.303121, 41.624633],
+                        [-86.305495, 41.624416],
+                        [-86.307875, 41.624237],
+                        [-86.310259, 41.624096],
+                        [-86.312647, 41.623994],
+                        [-86.315037, 41.62393],
+                        [-86.317428, 41.623905],
+                        [-86.31982, 41.623919],
+                        [-86.32221, 41.623971],
+                        [-86.324599, 41.624062],
+                        [-86.326984, 41.624192],
+                        [-86.329365, 41.624359],
+                        [-86.331741, 41.624566],
+                        [-86.33411, 41.62481],
+                        [-86.336472, 41.625093],
+                        [-86.338825, 41.625414],
+                        [-86.341168, 41.625772],
+                        [-86.343501, 41.626169],
+                        [-86.345821, 41.626603],
+                        [-86.348129, 41.627074],
+                        [-86.350423, 41.627582],
+                        [-86.352701, 41.628128],
+                        [-86.354964, 41.62871],
+                        [-86.357215, 41.629316],
+                        [-86.335687, 41.653205],
+                        [-86.334459, 41.654687],
+                        [-86.33348, 41.656271],
+                        [-86.332726, 41.657924],
+                        [-86.332206, 41.659626],
+                        [-86.331926, 41.66136],
+                        [-86.331888, 41.663106],
+                        [-86.332094, 41.664846],
+                        [-86.332541, 41.66656],
+                        [-86.333224, 41.66823],
+                        [-86.334135, 41.669837],
+                        [-86.335265, 41.671364],
+                        [-86.336602, 41.672794],
+                        [-86.33813, 41.674112],
+                        [-86.339834, 41.675304],
+                        [-86.341694, 41.676355],
+                        [-86.34369, 41.677255],
+                        [-86.345801, 41.677994],
+                        [-86.348003, 41.678564],
+                        [-86.350272, 41.678958],
+                        [-86.352584, 41.679173],
+                        [-86.354913, 41.679206],
+                        [-86.357234, 41.679056],
+                        [-86.359522, 41.678726],
+                        [-86.361751, 41.678218],
+                        [-86.363897, 41.677539],
+                        [-86.365937, 41.676695],
+                        [-86.367848, 41.675697],
+                        [-86.36961, 41.674554],
+                        [-86.371203, 41.67328],
+                        [-86.37261, 41.671888],
+                        [-86.394804, 41.647166],
+                        [-86.396512, 41.648423],
+                        [-86.398182, 41.649707],
+                        [-86.399816, 41.651018],
+                        [-86.401412, 41.652355],
+                        [-86.402969, 41.653718],
+                        [-86.404486, 41.655105],
+                        [-86.405964, 41.656517],
+                        [-86.407401, 41.657952],
+                        [-86.408796, 41.659409],
+                        [-86.410149, 41.66089],
+                        [-86.411459, 41.662391],
+                        [-86.412726, 41.663913],
+                        [-86.413949, 41.665456],
+                        [-86.415128, 41.667018],
+                        [-86.416261, 41.668598],
+                        [-86.417349, 41.670196],
+                        [-86.41839, 41.671812],
+                        [-86.419386, 41.673444],
+                        [-86.420334, 41.675092],
+                        [-86.421234, 41.676754],
+                        [-86.422087, 41.678431],
+                        [-86.422891, 41.680121],
+                        [-86.423646, 41.681824],
+                        [-86.424353, 41.683538],
+                        [-86.42501, 41.685264],
+                        [-86.425618, 41.687],
+                        [-86.426175, 41.688745],
+                        [-86.426683, 41.690499],
+                        [-86.42714, 41.69226],
+                        [-86.427546, 41.694029],
+                        [-86.427901, 41.695803],
+                        [-86.428205, 41.697583],
+                        [-86.428458, 41.699368],
+                        [-86.428659, 41.701156],
+                        [-86.42881, 41.702947],
+                        [-86.428908, 41.70474],
+                        [-86.428955, 41.706534],
+                        [-86.428951, 41.708328],
+                        [-86.428895, 41.710122],
+                        [-86.428787, 41.711915],
+                        [-86.428628, 41.713705],
+                        [-86.428418, 41.715493],
+                        [-86.428156, 41.717276],
+                        [-86.427843, 41.719055],
+                        [-86.427479, 41.720829],
+                        [-86.427063, 41.722596],
+                        [-86.426598, 41.724356],
+                        [-86.426081, 41.726109],
+                        [-86.425515, 41.727852],
+                        [-86.424898, 41.729586],
+                        [-86.424232, 41.73131],
+                        [-86.423516, 41.733022],
+                        [-86.422751, 41.734723],
+                        [-86.421937, 41.73641],
+                        [-86.421075, 41.738085],
+                        [-86.420165, 41.739744],
+                        [-86.419207, 41.741389],
+                        [-86.418202, 41.743018],
+                        [-86.417151, 41.744631],
+                        [-86.416053, 41.746226],
+                        [-86.41491, 41.747803],
+                        [-86.413722, 41.749361],
+                        [-86.412489, 41.7509],
+                        [-86.411212, 41.752418],
+                        [-86.409891, 41.753915],
+                        [-86.408528, 41.755391],
+                        [-86.407122, 41.756845],
+                        [-86.405675, 41.758275],
+                        [-86.404187, 41.759682],
+                        [-86.402659, 41.761064],
+                        [-86.401092, 41.762421],
+                        [-86.399485, 41.763753],
+                        [-86.397841, 41.765059],
+                        [-86.39616, 41.766337],
+                        [-86.394442, 41.767589],
+                        [-86.392688, 41.768812],
+                        [-86.390899, 41.770006],
+                        [-86.389077, 41.771172],
+                        [-86.387221, 41.772308],
+                        [-86.385333, 41.773413],
+                        [-86.383414, 41.774488],
+                        [-86.381464, 41.775532],
+                        [-86.379484, 41.776544],
+                        [-86.377476, 41.777524],
+                        [-86.37544, 41.778471],
+                        [-86.373377, 41.779385],
+                        [-86.371288, 41.780265],
+                        [-86.369174, 41.781112],
+                        [-86.367036, 41.781924],
+                        [-86.364876, 41.782702],
+                        [-86.362693, 41.783445],
+                        [-86.36049, 41.784152],
+                        [-86.358266, 41.784823],
+                        [-86.356024, 41.785459],
+                        [-86.353764, 41.786058],
+                        [-86.351487, 41.78662],
+                        [-86.349195, 41.787146],
+                        [-86.346888, 41.787634],
+                        [-86.344567, 41.788085],
+                        [-86.342234, 41.788499],
+                        [-86.33989, 41.788875],
+                        [-86.337535, 41.789213],
+                        [-86.335171, 41.789512],
+                        [-86.332799, 41.789774],
+                        [-86.33042, 41.789997],
+                        [-86.328035, 41.790182],
+                        [-86.325645, 41.790328],
+                        [-86.323252, 41.790436],
+                        [-86.320856, 41.790505],
+                        [-86.318458, 41.790535],
+                        [-86.316061, 41.790527],
+                        [-86.313664, 41.79048],
+                        [-86.311269, 41.790394],
+                        [-86.308877, 41.79027],
+                        [-86.306489, 41.790107],
+                        [-86.304107, 41.789906],
+                        [-86.30173, 41.789666],
+                        [-86.299362, 41.789388],
+                        [-86.297002, 41.789071],
+                        [-86.294651, 41.788717],
+                        [-86.292311, 41.788325],
+                        [-86.289984, 41.787895],
+                        [-86.287669, 41.787428],
+                        [-86.285368, 41.786923],
+                        [-86.283082, 41.786382],
+                        [-86.280812, 41.785804],
+                        [-86.27856, 41.785189],
+                        [-86.276326, 41.784538],
+                        [-86.274111, 41.783851],
+                        [-86.271916, 41.783128],
+                        [-86.269743, 41.782371],
+                        [-86.267592, 41.781578],
+                        [-86.265465, 41.780751],
+                        [-86.263362, 41.77989],
+                        [-86.261284, 41.778994],
+                        [-86.259232, 41.778066],
+                        [-86.257208, 41.777105],
+                        [-86.255212, 41.776111],
+                        [-86.253245, 41.775085],
+                        [-86.251308, 41.774028],
+                        [-86.249402, 41.77294],
+                        [-86.247528, 41.771821],
+                        [-86.245687, 41.770673],
+                        [-86.243879, 41.769495],
+                        [-86.242105, 41.768287],
+                        [-86.240367, 41.767052],
+                        [-86.238664, 41.765789],
+                        [-86.236999, 41.764499],
+                        [-86.235371, 41.763182],
+                        [-86.233781, 41.761839],
+                        [-86.232231, 41.760471],
+                        [-86.23072, 41.759078],
+                        [-86.229249, 41.757661],
+                        [-86.22782, 41.75622],
+                        [-86.226433, 41.754757],
+                        [-86.225088, 41.753272],
+                        [-86.223786, 41.751765],
+                        [-86.222528, 41.750238],
+                        [-86.221314, 41.748691],
+                        [-86.220145, 41.747125],
+                        [-86.219022, 41.74554],
+                        [-86.217944, 41.743937],
+                        [-86.216913, 41.742317],
+                        [-86.215928, 41.740682],
+                        [-86.214991, 41.73903],
+                        [-86.214102, 41.737364],
+                        [-86.21326, 41.735684],
+                        [-86.212468, 41.73399],
+                        [-86.211724, 41.732285],
+                        [-86.211029, 41.730567],
+                        [-86.210384, 41.728839],
+                        [-86.209789, 41.727101],
+                        [-86.209244, 41.725354],
+                        [-86.20875, 41.723598],
+                        [-86.208306, 41.721835],
+                        [-86.207912, 41.720064],
+                        [-86.20757, 41.718288],
+                        [-86.207279, 41.716507],
+                        [-86.20704, 41.714722],
+                        [-86.206851, 41.712933],
+                        [-86.206714, 41.711142],
+                        [-86.206629, 41.709348],
+                        [-86.206595, 41.707554],
+                        [-86.206613, 41.70576],
+                        [-86.206682, 41.703966],
+                        [-86.206803, 41.702174],
+                        [-86.206976, 41.700384],
+                        [-86.207199, 41.698597],
+                        [-86.207474, 41.696815],
+                        [-86.207801, 41.695037],
+                        [-86.208178, 41.693265],
+                        [-86.208606, 41.6915],
+                        [-86.209083, 41.689741],
+                        [-86.209612, 41.687991],
+                        [-86.210191, 41.68625],
+                        [-86.21082, 41.684518],
+                        [-86.211499, 41.682797],
+                        [-86.212226, 41.681088],
+                        [-86.213003, 41.67939]
+                      ]
+                    ],
+                    "type": "Polygon"
+                  },
+                  "properties": {
+                    "airspace_type": "CAS",
+                    "cas_class": "E2",
+                    "ceiling": 18000,
+                    "floor": 0,
+                    "laanc": true,
+                    "name": "SOUTH BEND, MICHIANA REGIONAL AIRPORT CLASS E2"
+                  },
+                  "type": "Feature"
+                }
+              ],
+              "type": "FeatureCollection"
+            }
+          ]
+        },
+        "properties": {
+          "found": {
+            "items": {
+              "type": "object"
+            },
+            "title": "Found",
+            "type": "array"
+          }
+        },
+        "required": ["found"],
+        "title": "AirspacePolyResponse",
+        "type": "object"
+      },
+      "AirspaceRouteResponse": {
+        "example": {
+          "found": [
+            {
+              "features": [
+                {
+                  "geometry": {
+                    "coordinates": [
+                      [
+                        [-87.449799, 36.341015],
+                        [-87.478627, 36.33957],
+                        [-87.50751, 36.339742],
+                        [-87.536308, 36.341529],
+                        [-87.564884, 36.344924],
+                        [-87.593099, 36.349909],
+                        [-87.620819, 36.35646],
+                        [-87.647909, 36.364547],
+                        [-87.674239, 36.37413],
+                        [-87.699681, 36.385163],
+                        [-87.724113, 36.397593],
+                        [-87.747417, 36.41136],
+                        [-87.769479, 36.426398],
+                        [-87.790193, 36.442633],
+                        [-87.809457, 36.459989],
+                        [-87.827178, 36.47838],
+                        [-87.843268, 36.497718],
+                        [-87.857649, 36.51791],
+                        [-87.87025, 36.538857],
+                        [-87.881008, 36.560459],
+                        [-87.889869, 36.58261],
+                        [-87.896789, 36.605203],
+                        [-87.901732, 36.628128],
+                        [-87.904673, 36.651275],
+                        [-87.905596, 36.674529],
+                        [-87.904494, 36.697778],
+                        [-87.90137, 36.720909],
+                        [-87.896239, 36.743809],
+                        [-87.889123, 36.766366],
+                        [-87.880056, 36.78847],
+                        [-87.86908, 36.810012],
+                        [-87.856247, 36.830887],
+                        [-87.841619, 36.850994],
+                        [-87.825266, 36.870232],
+                        [-87.807267, 36.888509],
+                        [-87.787709, 36.905733],
+                        [-87.766687, 36.921821],
+                        [-87.744305, 36.936694],
+                        [-87.72067, 36.950277],
+                        [-87.6959, 36.962505],
+                        [-87.670115, 36.973316],
+                        [-87.643442, 36.982659],
+                        [-87.616012, 36.990486],
+                        [-87.587961, 36.996759],
+                        [-87.559427, 37.001448],
+                        [-87.530549, 37.004528],
+                        [-87.501472, 37.005985],
+                        [-87.472338, 37.005812],
+                        [-87.443292, 37.004009],
+                        [-87.414475, 37.000585],
+                        [-87.386032, 36.995558],
+                        [-87.358101, 36.988951],
+                        [-87.330821, 36.980799],
+                        [-87.304326, 36.97114],
+                        [-87.278747, 36.960022],
+                        [-87.254208, 36.947501],
+                        [-87.23083, 36.933638],
+                        [-87.208727, 36.918501],
+                        [-87.188009, 36.902165],
+                        [-87.168774, 36.884709],
+                        [-87.151118, 36.866221],
+                        [-87.135125, 36.84679],
+                        [-87.120873, 36.826512],
+                        [-87.10843, 36.805486],
+                        [-87.097856, 36.783815],
+                        [-87.0892, 36.761606],
+                        [-87.082503, 36.738967],
+                        [-87.077797, 36.716009],
+                        [-87.075102, 36.692843],
+                        [-87.074431, 36.669583],
+                        [-87.075783, 36.646342],
+                        [-87.079151, 36.623234],
+                        [-87.084517, 36.60037],
+                        [-87.091305, 36.582541],
+                        [-87.449918, 36.340561],
+                        [-87.449799, 36.341015]
+                      ]
+                    ],
+                    "type": "Polygon"
+                  },
+                  "properties": {
+                    "airspace_type": "SUA",
+                    "ceiling": 2000,
+                    "ceiling_ref": "MSL",
+                    "ceiling_uom": "FT",
+                    "floor": 0,
+                    "floor_ref": "AGL",
+                    "floor_uom": "FT",
+                    "name": "A-371 FORT CAMPBELL, KY",
+                    "sua_type": "AA"
+                  },
+                  "type": "Feature"
+                }
+              ],
+              "type": "FeatureCollection"
+            },
+            {
+              "features": [
+                {
+                  "geometry": {
+                    "coordinates": [
+                      [
+                        [-87.393384, 36.602072],
+                        [-87.393465, 36.600438],
+                        [-87.393705, 36.59882],
+                        [-87.394102, 36.597234],
+                        [-87.394653, 36.595694],
+                        [-87.395352, 36.594215],
+                        [-87.396193, 36.592812],
+                        [-87.397167, 36.591499],
+                        [-87.398266, 36.590287],
+                        [-87.399478, 36.589188],
+                        [-87.400791, 36.588214],
+                        [-87.402194, 36.587373],
+                        [-87.403673, 36.586674],
+                        [-87.405213, 36.586123],
+                        [-87.406799, 36.585725],
+                        [-87.408417, 36.585485],
+                        [-87.410051, 36.585405],
+                        [-87.411685, 36.585485],
+                        [-87.413302, 36.585725],
+                        [-87.414889, 36.586123],
+                        [-87.416429, 36.586674],
+                        [-87.417908, 36.587373],
+                        [-87.41931, 36.588214],
+                        [-87.420624, 36.589188],
+                        [-87.421836, 36.590287],
+                        [-87.422934, 36.591499],
+                        [-87.423909, 36.592812],
+                        [-87.42475, 36.594215],
+                        [-87.425449, 36.595694],
+                        [-87.426, 36.597234],
+                        [-87.426397, 36.59882],
+                        [-87.426637, 36.600438],
+                        [-87.426718, 36.602072],
+                        [-87.426637, 36.603706],
+                        [-87.426397, 36.605323],
+                        [-87.426, 36.60691],
+                        [-87.425449, 36.60845],
+                        [-87.42475, 36.609929],
+                        [-87.423909, 36.611331],
+                        [-87.422934, 36.612645],
+                        [-87.421836, 36.613857],
+                        [-87.420624, 36.614955],
+                        [-87.41931, 36.61593],
+                        [-87.417908, 36.616771],
+                        [-87.416429, 36.61747],
+                        [-87.414889, 36.618021],
+                        [-87.413302, 36.618418],
+                        [-87.411685, 36.618658],
+                        [-87.410051, 36.618739],
+                        [-87.408417, 36.618658],
+                        [-87.406799, 36.618418],
+                        [-87.405213, 36.618021],
+                        [-87.403673, 36.61747],
+                        [-87.402194, 36.616771],
+                        [-87.400791, 36.61593],
+                        [-87.399478, 36.614955],
+                        [-87.398266, 36.613857],
+                        [-87.397167, 36.612645],
+                        [-87.396193, 36.611331],
+                        [-87.395352, 36.609929],
+                        [-87.394653, 36.60845],
+                        [-87.394102, 36.60691],
+                        [-87.393705, 36.605323],
+                        [-87.393465, 36.603706],
+                        [-87.393384, 36.602072]
+                      ]
+                    ],
+                    "type": "Polygon"
+                  },
+                  "properties": {
+                    "airspace_type": "MAA",
+                    "maa_type": "PARACHUTE JUMP AREA",
+                    "name": "SON DROP ZONE"
+                  },
+                  "type": "Feature"
+                }
+              ],
+              "type": "FeatureCollection"
+            }
+          ]
+        },
+        "properties": {
+          "found": {
+            "items": {
+              "type": "object"
+            },
+            "title": "Found",
+            "type": "array"
+          }
+        },
+        "required": ["found"],
+        "title": "AirspaceRouteResponse",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "NOTAMsByDistance": {
+        "description": "Geometry-defining arguments for point/distance requests",
+        "example": {
+          "distance": 5000,
+          "latitude": 35.753,
+          "longitude": -105.416
+        },
+        "properties": {
+          "distance": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Distance"
+          },
+          "latitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Latitude"
+          },
+          "longitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Longitude"
+          }
+        },
+        "required": ["longitude", "latitude", "distance"],
+        "title": "NOTAMsByDistance",
+        "type": "object"
+      },
+      "NOTAMsByPolygon": {
+        "description": "Geometry-defining arguments for polygon requests",
+        "example": {
+          "poly": {
+            "coordinates": [
+              [
+                [-155.426425, 19.545118],
+                [-155.59946, 19.440516],
+                [-155.348422, 19.335847],
+                [-155.426425, 19.545118]
+              ]
+            ],
+            "type": "Polygon"
+          }
+        },
+        "properties": {
+          "poly": {
+            "title": "Poly",
+            "type": "object"
+          }
+        },
+        "required": ["poly"],
+        "title": "NOTAMsByPolygon",
+        "type": "object"
+      },
+      "NOTAMsByRoute": {
+        "description": "Geometry-defining arguments for along-route requests",
+        "example": {
+          "route": {
+            "coordinates": [
+              [-80.135, 25.783],
+              [-80.127, 25.797],
+              [-80.128, 25.812],
+              [-80.132, 25.824]
+            ],
+            "type": "LineString"
+          }
+        },
+        "properties": {
+          "route": {
+            "title": "Route",
+            "type": "object"
+          }
+        },
+        "required": ["route"],
+        "title": "NOTAMsByRoute",
+        "type": "object"
+      },
+      "NOTAMsDistanceResponse": {
+        "example": {
+          "found": {
+            "features": [
+              {
+                "geometry": {
+                  "geometries": [
+                    {
+                      "coordinates": [
+                        [
+                          [-105.679167, 36.016667],
+                          [-105.479167, 35.95],
+                          [-105.35, 35.870833],
+                          [-105.104167, 35.795833],
+                          [-105.183333, 35.666667],
+                          [-105.158333, 35.4375],
+                          [-105.666667, 35.508333],
+                          [-105.679167, 36.016667]
+                        ]
+                      ],
+                      "heightInformation": {
+                        "lowerLevel": "0",
+                        "uomLowerLevel": "FT",
+                        "uomUpperLevel": "FT",
+                        "upperLevel": "17500"
+                      },
+                      "type": "Polygon"
+                    }
+                  ],
+                  "type": "GeometryCollection"
+                },
+                "properties": {
+                  "endDateTime": "2022-06-17T03:00:00.000Z",
+                  "notam_number": "2/4399",
+                  "startDateTime": "2022-05-16T06:00:00.000Z",
+                  "text": "NM..AIRSPACE LAS VEGAS, NM..TEMPORARY FLIGHTRESTRICTIONS WI AN AREA BOUNDED BY360100N1054045W (FTI296034.1) TO355700N1052845W (FTI303024.3) TO355215N1052100W (FTI308016.5) TO354745N1050615W (FTI357008.4) TO354000N1051100W (FTI270002.4) TO352615N1050930W (FTI172013.2) TO353030N1054000W (FTI238027.5) TO POINT OF ORIGINSFC-17500FT. TO PROVIDE A SAFE ENVIRONMENT FOR FIRE FIGHTINGACFT OPS. PURSUANT TO 14 CFR SECTION 91.137(A)(2) TEMPORARYFLIGHT RESTRICTIONS ARE IN EFFECT. SANTA FE DISPATCH CENTERTEL 505-438-5600 OR FREQ 118.250/SOUTHERN ZONE HERMITSPEAK/CALF CANYON FIRE IS IN CHARGE OF THE OPS. ALBUQUERQUE/ZAB/ ARTCC TEL 505-856-4591 IS THE FAA CDN FACILITY."
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "geometries": [
+                    {
+                      "coordinates": [
+                        [
+                          [-105.504167, 36.516667],
+                          [-105.229167, 36.529167],
+                          [-105.2375, 36.4625],
+                          [-104.929167, 36.370833],
+                          [-105.104167, 35.795833],
+                          [-105.35, 35.870833],
+                          [-105.479167, 35.95],
+                          [-105.679167, 36.016667],
+                          [-105.504167, 36.516667]
+                        ]
+                      ],
+                      "heightInformation": {
+                        "lowerLevel": "0",
+                        "uomLowerLevel": "FT",
+                        "uomUpperLevel": "FT",
+                        "upperLevel": "17500"
+                      },
+                      "type": "Polygon"
+                    }
+                  ],
+                  "type": "GeometryCollection"
+                },
+                "properties": {
+                  "endDateTime": "2022-06-17T03:00:00.000Z",
+                  "notam_number": "2/4451",
+                  "startDateTime": "2022-05-16T06:00:00.000Z",
+                  "text": "NM..AIRSPACE 34NM N LAS VEGAS, NM..TEMPORARY FLIGHTRESTRICTIONS WI AN AREA DEFINED AS363100N1053015W (CIM260030.6) TO363145N1051345W (CIM264017.4) TO362745N1051415W (CIM251017.8) TO362215N1045545W (CIM188007.7) TO354745N1050615W (FTI357008.4) TO355215N1052100W (FTI308016.5) TO355700N1052845W (FTI303024.3) TO360100N1054045W (FTI296034.1) TO POINT OF ORIGIN SFC-17500FT TOPROVIDE A SAFE ENVIRONMENT FOR FIRE FIGHTING ACFT OPS. PURSUANT TO14 CFR SECTION 91.137(A)(2) TEMPORARY FLIGHT RESTRICTIONS ARE INEFFECT. SANTA FE DISPATCH CENTER TEL 505-438-5600 OR FREQ125.875/CENTRAL ZONE HERMITS PEAK/CALF CANYON FIRE IS IN CHARGE OFTHE OPS. ALBUQUERQUE /ZAB/ ARTCC TEL 505-856-4591 IS THE FAA CDNFAC."
+                },
+                "type": "Feature"
+              }
+            ],
+            "type": "FeatureCollection"
+          }
+        },
+        "properties": {
+          "found": {
+            "title": "Found",
+            "type": "object"
+          }
+        },
+        "required": ["found"],
+        "title": "NOTAMsDistanceResponse",
+        "type": "object"
+      },
+      "NOTAMsPolyResponse": {
+        "example": {
+          "found": {
+            "found": {
+              "features": [
+                {
+                  "geometry": {
+                    "geometries": [
+                      {
+                        "coordinates": [
+                          [
+                            [-155.295, 19.424444],
+                            [-155.258333, 19.428611],
+                            [-155.274167, 19.343611],
+                            [-155.366111, 19.368889],
+                            [-155.295, 19.424444]
+                          ]
+                        ],
+                        "heightInformation": {
+                          "lowerLevel": "0",
+                          "uomLowerLevel": "FT",
+                          "uomUpperLevel": "FT",
+                          "upperLevel": "1500"
+                        },
+                        "type": "Polygon"
+                      },
+                      {
+                        "coordinates": [
+                          [
+                            [-155.471389, 19.687222],
+                            [-155.395833, 19.677778],
+                            [-155.546389, 19.421667],
+                            [-155.661944, 19.465],
+                            [-155.471389, 19.687222]
+                          ]
+                        ],
+                        "heightInformation": {
+                          "lowerLevel": "0",
+                          "uomLowerLevel": "FT",
+                          "uomUpperLevel": "FT",
+                          "upperLevel": "1500"
+                        },
+                        "type": "Polygon"
+                      }
+                    ],
+                    "type": "GeometryCollection"
+                  },
+                  "properties": {
+                    "endDateTime": "2022-12-20T23:59:00.000Z",
+                    "notam_number": "2/1356",
+                    "startDateTime": "2022-09-21T22:30:00.000Z",
+                    "text": "HI..AIRSPACE KILAUEA, HI..TEMPORARY FLIGHTRESTRICTIONS WI AN AREA DEFINED AS192528N1551742W (ITO211024.0) TO192543N1551530W (ITO208022.4) TO192037N1551627W (ITO202027.1) TO192208N1552158W (ITO213029.1) TOPOINT OF ORIGIN. SFC-1500FT AGL VOLCANIC ACT.PURSUANT TO 14 CFR SECTION 91.137(A)(1) TEMPORARY FLIGHTRESTRICTIONS ARE IN EFFECT. ONLY RELIEF ACFT OPS UNDERDIRECTION OF HAWAII VOLCANOES NATIONAL PARK SERVICE ARE AUTHIN THE AIRSPACE. HAWAII VOLCANOES NATIONAL PARK SERVICE TEL808-985-6170 IS IN CHARGE OF ON SCENE EMERG RESPONSE ACT.HONOLULU /ZHN/ ARTCC TEL 808-840-6201 IS THE FAA CDNFACILITY."
+                  },
+                  "type": "Feature"
+                },
+                {
+                  "geometry": {
+                    "geometries": [
+                      {
+                        "coordinates": [
+                          [
+                            [-155.295, 19.424444],
+                            [-155.258333, 19.428611],
+                            [-155.274167, 19.343611],
+                            [-155.366111, 19.368889],
+                            [-155.295, 19.424444]
+                          ]
+                        ],
+                        "heightInformation": {
+                          "lowerLevel": "0",
+                          "uomLowerLevel": "FT",
+                          "uomUpperLevel": "FT",
+                          "upperLevel": "1500"
+                        },
+                        "type": "Polygon"
+                      },
+                      {
+                        "coordinates": [
+                          [
+                            [-155.471389, 19.687222],
+                            [-155.395833, 19.677778],
+                            [-155.546389, 19.421667],
+                            [-155.661944, 19.465],
+                            [-155.471389, 19.687222]
+                          ]
+                        ],
+                        "heightInformation": {
+                          "lowerLevel": "0",
+                          "uomLowerLevel": "FT",
+                          "uomUpperLevel": "FT",
+                          "upperLevel": "1500"
+                        },
+                        "type": "Polygon"
+                      }
+                    ],
+                    "type": "GeometryCollection"
+                  },
+                  "properties": {
+                    "endDateTime": "2022-12-08T23:59:00.000Z",
+                    "notam_number": "2/9210",
+                    "startDateTime": "2022-12-02T05:00:00.000Z",
+                    "text": "HI..AIRSPACE MAUNA LOA, HI..TEMPORARY FLIGHTRESTRICTIONS WI AN AREA DEFINED AS194114N1552817W (KOA082032.5) TO194040N1552345W (KOA083036.8) TO192518N1553247W (KOA111033.3) TO192754N1553943W (KOA114026.4) TO POINT OF ORIGINSFC-1500FT AGL VOLCANIC ACTIVITY. PURSUANT TO 14 CFR SECTION91.137(A)(1) TEMPORARY FLIGHT RESTRICTIONS ARE IN EFFECT. ONLYRELIEF AIRCRAFT OPERATIONS UNDER DIRECTION OF HAWAII VOLCANOESNATIONAL PARK ARE AUTHORIZED IN THE AIRSPACE. HAWAII VOLCANOESNATIONAL PARK TELEPHONE 808-985-6170 IS IN CHARGE OF ON SCENEEMERGENCY RESPONSE ACTIVITY. HONOLULU /ZHN/ ARTCC TELEPHONE808-840-6201 IS THE FAA COORDINATION FACILITY."
+                  },
+                  "type": "Feature"
+                }
+              ],
+              "type": "FeatureCollection"
+            }
+          }
+        },
+        "properties": {
+          "found": {
+            "title": "Found",
+            "type": "object"
+          }
+        },
+        "required": ["found"],
+        "title": "NOTAMsPolyResponse",
+        "type": "object"
+      },
+      "NOTAMsRouteResponse": {
+        "example": {
+          "found": {
+            "features": [
+              {
+                "geometry": {
+                  "geometries": [
+                    {
+                      "coordinates": [
+                        [
+                          [-80.122778, 25.866363],
+                          [-80.106735, 25.865092],
+                          [-80.091181, 25.861319],
+                          [-80.076589, 25.855157],
+                          [-80.063402, 25.846796],
+                          [-80.052023, 25.836488],
+                          [-80.042797, 25.824548],
+                          [-80.036003, 25.81134],
+                          [-80.031847, 25.797264],
+                          [-80.030456, 25.782748],
+                          [-80.031869, 25.768235],
+                          [-80.036044, 25.754164],
+                          [-80.042853, 25.740963],
+                          [-80.052087, 25.729033],
+                          [-80.063466, 25.718735],
+                          [-80.076645, 25.710383],
+                          [-80.091223, 25.704229],
+                          [-80.106757, 25.700461],
+                          [-80.122778, 25.699192],
+                          [-80.138798, 25.700461],
+                          [-80.154333, 25.704229],
+                          [-80.168911, 25.710383],
+                          [-80.182089, 25.718735],
+                          [-80.193469, 25.729033],
+                          [-80.202703, 25.740963],
+                          [-80.209511, 25.754164],
+                          [-80.213686, 25.768235],
+                          [-80.2151, 25.782748],
+                          [-80.213708, 25.797264],
+                          [-80.209553, 25.81134],
+                          [-80.202759, 25.824548],
+                          [-80.193532, 25.836488],
+                          [-80.182153, 25.846796],
+                          [-80.168967, 25.855157],
+                          [-80.154375, 25.861319],
+                          [-80.13882, 25.865092],
+                          [-80.122778, 25.866363]
+                        ]
+                      ],
+                      "heightInformation": {
+                        "lowerLevel": "0",
+                        "uomLowerLevel": "FT",
+                        "uomUpperLevel": "FT",
+                        "upperLevel": "15000"
+                      },
+                      "type": "Polygon"
+                    }
+                  ],
+                  "type": "GeometryCollection"
+                },
+                "properties": {
+                  "endDateTime": "2022-05-29T22:00:00.000Z",
+                  "notam_number": "2/6642",
+                  "startDateTime": "2022-05-27T14:30:00.000Z",
+                  "text": "FL..AIRSPACE MIAMI BEACH, FL..TEMPORARY FLIGHTRESTRICTION. PURSUANT TO 14 CFR SECTION 91.145, MANAGEMENTOF ACFT OPS IN THE VICINITY OF AERIAL DEMONSTRATIONS AND MAJORSPORTING EVENTS, ACFT OPS ARE PROHIBITED WI AN AREA DEFINED AS 5NMRADIUS OF 254658N0800722W (VKZ047002.5) SFC-15000FT UNLESS AUTH BYATC. EFFECTIVE 2205271430 UTC UNTIL 2205272000 UTC, 2205281630 UTC UNTIL 2205282200 UTC, 2205282300 UTC UNTIL 2205290000 UTC, 2205290100 UTC UNTIL 2205290200 UTC, AND 2205291630 UTC UNTIL 2205292200 UTC. DUE TO MIAMI BEACH AIR AND SEA SHOW AERIAL DEMONSTRATIONS. JIMTUCCIARONE, TEL 216-390-8410, IS THE AIRSHOW POINT OF CTC. MIAMI/MIA/ APP, TEL 305-869-5477, IS THE FAA CDN FAC. ."
+                },
+                "type": "Feature"
+              }
+            ],
+            "type": "FeatureCollection"
+          }
+        },
+        "properties": {
+          "found": {
+            "title": "Found",
+            "type": "object"
+          }
+        },
+        "required": ["found"],
+        "title": "NOTAMsRouteResponse",
+        "type": "object"
+      },
+      "ObstacleDistanceResponse": {
+        "example": {
+          "found": {
+            "features": [
+              {
+                "geometry": {
+                  "coordinates": [-79.963714, 40.220953],
+                  "type": "Point"
+                },
+                "properties": {
+                  "height_ft": 212,
+                  "lighting": "None",
+                  "marking": "Spherical Marker",
+                  "name": "MONONGAHELA-PA-025677",
+                  "obstacle_type": "CATENARY",
+                  "quantity": 1
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-79.963137, 40.22185],
+                  "type": "Point"
+                },
+                "properties": {
+                  "height_ft": 220,
+                  "lighting": "None",
+                  "marking": "Spherical Marker",
+                  "name": "MONONGAHELA-PA-020575",
+                  "obstacle_type": "CATENARY",
+                  "quantity": 1
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-79.956389, 40.224167],
+                  "type": "Point"
+                },
+                "properties": {
+                  "height_ft": 141,
+                  "lighting": "None",
+                  "marking": "None",
+                  "name": "MONONGAHELA-PA-000366",
+                  "obstacle_type": "T-L TWR",
+                  "quantity": 1
+                },
+                "type": "Feature"
+              }
+            ],
+            "type": "FeatureCollection"
+          }
+        },
+        "properties": {
+          "found": {
+            "title": "Found",
+            "type": "object"
+          }
+        },
+        "required": ["found"],
+        "title": "ObstacleDistanceResponse",
+        "type": "object"
+      },
+      "ObstaclePolyResponse": {
+        "example": {
+          "found": {
+            "features": [
+              {
+                "geometry": {
+                  "coordinates": [-90.1225, 35.07],
+                  "type": "Point"
+                },
+                "properties": {
+                  "height_ft": 309,
+                  "lighting": "Medium Intensity White Strobe",
+                  "marking": "Marked",
+                  "name": "MEMPHIS-TN-000197",
+                  "obstacle_type": "TOWER",
+                  "quantity": 2
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-90.130556, 35.072223],
+                  "type": "Point"
+                },
+                "properties": {
+                  "height_ft": 378,
+                  "lighting": "Red",
+                  "marking": "Marked",
+                  "name": "MEMPHIS-TN-000414",
+                  "obstacle_type": "TOWER",
+                  "quantity": 1
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-90.151389, 35.077778],
+                  "type": "Point"
+                },
+                "properties": {
+                  "height_ft": 244,
+                  "lighting": "Red",
+                  "marking": "Orange or Orange and White Paint",
+                  "name": "MEMPHIS-TN-000755",
+                  "obstacle_type": "T-L TWR",
+                  "quantity": 1
+                },
+                "type": "Feature"
+              }
+            ],
+            "type": "FeatureCollection"
+          }
+        },
+        "properties": {
+          "found": {
+            "title": "Found",
+            "type": "object"
+          }
+        },
+        "required": ["found"],
+        "title": "ObstaclePolyResponse",
+        "type": "object"
+      },
+      "ObstacleRouteResponse": {
+        "example": {
+          "found": {
+            "features": [
+              {
+                "geometry": {
+                  "coordinates": [-86.909834, 41.716],
+                  "type": "Point"
+                },
+                "properties": {
+                  "height_ft": 265,
+                  "lighting": "Medium intensity White Strobe & Red",
+                  "marking": "None",
+                  "name": "MICHIGAN CITY-IN-001849",
+                  "obstacle_type": "TOWER",
+                  "quantity": 1
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-86.909224, 41.716067],
+                  "type": "Point"
+                },
+                "properties": {
+                  "height_ft": 200,
+                  "lighting": "None",
+                  "marking": "None",
+                  "name": "MICHIGAN CITY-IN-026462",
+                  "obstacle_type": "TOWER",
+                  "quantity": 1
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-86.91, 41.72],
+                  "type": "Point"
+                },
+                "properties": {
+                  "height_ft": 216,
+                  "lighting": "None",
+                  "marking": "None",
+                  "name": "MICHIGAN CITY-IN-000595",
+                  "obstacle_type": "TOWER",
+                  "quantity": 1
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-86.909995, 41.72005],
+                  "type": "Point"
+                },
+                "properties": {
+                  "height_ft": 300,
+                  "lighting": "Medium intensity White Strobe & Red",
+                  "marking": "None",
+                  "name": "MICHIGAN CITY-IN-054972",
+                  "obstacle_type": "TOWER",
+                  "quantity": 1
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-86.909445, 41.721389],
+                  "type": "Point"
+                },
+                "properties": {
+                  "height_ft": 273,
+                  "lighting": "None",
+                  "marking": "None",
+                  "name": "MICHIGAN CITY-IN-000892",
+                  "obstacle_type": "BLDG",
+                  "quantity": 1
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-86.909167, 41.721945],
+                  "type": "Point"
+                },
+                "properties": {
+                  "height_ft": 500,
+                  "lighting": "High Intensity White Strobe",
+                  "marking": "None",
+                  "name": "MICHIGAN CITY-IN-000421",
+                  "obstacle_type": "STACK",
+                  "quantity": 1
+                },
+                "type": "Feature"
+              }
+            ],
+            "type": "FeatureCollection"
+          }
+        },
+        "properties": {
+          "found": {
+            "title": "Found",
+            "type": "object"
+          }
+        },
+        "required": ["found"],
+        "title": "ObstacleRouteResponse",
+        "type": "object"
+      },
+      "ObstaclesByDistance": {
+        "description": "Geometry-defining arguments for point/distance requests",
+        "example": {
+          "distance": 1500,
+          "latitude": 40.23,
+          "longitude": -79.96
+        },
+        "properties": {
+          "distance": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Distance"
+          },
+          "latitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Latitude"
+          },
+          "longitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Longitude"
+          }
+        },
+        "required": ["longitude", "latitude", "distance"],
+        "title": "ObstaclesByDistance",
+        "type": "object"
+      },
+      "ObstaclesByPolygon": {
+        "description": "Geometry-defining arguments for polygon requests",
+        "example": {
+          "poly": {
+            "coordinates": [
+              [
+                [-90.166, 35.078],
+                [-90.104, 35.066],
+                [-90.132, 35.085],
+                [-90.166, 35.078]
+              ]
+            ],
+            "type": "Polygon"
+          }
+        },
+        "properties": {
+          "poly": {
+            "title": "Poly",
+            "type": "object"
+          }
+        },
+        "required": ["poly"],
+        "title": "ObstaclesByPolygon",
+        "type": "object"
+      },
+      "ObstaclesByRoute": {
+        "description": "Geometry-defining arguments for along-route requests",
+        "example": {
+          "route": {
+            "coordinates": [
+              [-86.91, 41.728],
+              [-86.91, 41.718],
+              [-86.91, 41.715]
+            ],
+            "type": "LineString"
+          }
+        },
+        "properties": {
+          "route": {
+            "title": "Route",
+            "type": "object"
+          }
+        },
+        "required": ["route"],
+        "title": "ObstaclesByRoute",
+        "type": "object"
+      },
+      "SSAByDistance": {
+        "description": "Geometry-defining arguments for point/distance requests",
+        "example": {
+          "distance": 3000,
+          "latitude": 39.44,
+          "longitude": -77.39
+        },
+        "properties": {
+          "distance": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Distance"
+          },
+          "latitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Latitude"
+          },
+          "longitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Longitude"
+          }
+        },
+        "required": ["longitude", "latitude", "distance"],
+        "title": "SSAByDistance",
+        "type": "object"
+      },
+      "SSAByPolygon": {
+        "description": "Geometry-defining arguments for polygon requests",
+        "example": {
+          "poly": {
+            "coordinates": [
+              [
+                [-120.866559, 35.228447],
+                [-120.816434, 35.233719],
+                [-120.838956, 35.212853],
+                [-120.866559, 35.228447]
+              ]
+            ],
+            "type": "Polygon"
+          }
+        },
+        "properties": {
+          "poly": {
+            "title": "Poly",
+            "type": "object"
+          }
+        },
+        "required": ["poly"],
+        "title": "SSAByPolygon",
+        "type": "object"
+      },
+      "SSAByRoute": {
+        "description": "Geometry-defining arguments for along-route requests",
+        "example": {
+          "route": {
+            "coordinates": [
+              [-110.868783, 32.068473],
+              [-110.833353, 32.17129],
+              [-110.794351, 32.180124]
+            ],
+            "type": "LineString"
+          }
+        },
+        "properties": {
+          "route": {
+            "title": "Route",
+            "type": "object"
+          }
+        },
+        "required": ["route"],
+        "title": "SSAByRoute",
+        "type": "object"
+      },
+      "SSADistanceResponse": {
+        "example": {
+          "found": {
+            "features": [
+              {
+                "geometry": {
+                  "coordinates": [
+                    [
+                      [-77.392554, 39.439085],
+                      [-77.393842, 39.438085],
+                      [-77.396019, 39.439071],
+                      [-77.39598, 39.43912],
+                      [-77.396051, 39.439149],
+                      [-77.395266, 39.439478],
+                      [-77.395324, 39.439561],
+                      [-77.394057, 39.440216],
+                      [-77.392554, 39.439085]
+                    ]
+                  ],
+                  "type": "Polygon"
+                },
+                "properties": {
+                  "agency": "DOD",
+                  "ceiling": 400,
+                  "ceiling_ref": "AGL",
+                  "ceiling_uom": "FT",
+                  "contact_info": "LTC Jerry Lewis / 404 305-6916   Emergency: EOC 301-619-8547",
+                  "name": "Fort Detrick, Fort Detrick, MD 1"
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [
+                    [
+                      [-77.390944, 39.443122],
+                      [-77.392436, 39.442869],
+                      [-77.393704, 39.444463],
+                      [-77.39257, 39.445198],
+                      [-77.390944, 39.443122]
+                    ]
+                  ],
+                  "type": "Polygon"
+                },
+                "properties": {
+                  "agency": "DOD",
+                  "ceiling": 400,
+                  "ceiling_ref": "AGL",
+                  "ceiling_uom": "FT",
+                  "contact_info": "LTC Jerry Lewis / 404 305-6916   Emergency: EOC 301-619-8547",
+                  "name": "Fort Detrick, Fort Detrick, MD 3"
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [
+                    [
+                      [-77.411899, 39.449313],
+                      [-77.411588, 39.447153],
+                      [-77.411437, 39.446199],
+                      [-77.410915, 39.442566],
+                      [-77.410913, 39.442559],
+                      [-77.410912, 39.442548],
+                      [-77.41091, 39.442537],
+                      [-77.410908, 39.442526],
+                      [-77.410907, 39.442515],
+                      [-77.410906, 39.442507],
+                      [-77.410904, 39.442499],
+                      [-77.410903, 39.442488],
+                      [-77.410901, 39.442477],
+                      [-77.4109, 39.442468],
+                      [-77.410899, 39.442461],
+                      [-77.410897, 39.442449],
+                      [-77.410895, 39.442439],
+                      [-77.410894, 39.442428],
+                      [-77.410893, 39.44242],
+                      [-77.410891, 39.442412],
+                      [-77.410889, 39.442401],
+                      [-77.410888, 39.44239],
+                      [-77.410886, 39.442379],
+                      [-77.410885, 39.442371],
+                      [-77.410883, 39.442363],
+                      [-77.410881, 39.442352],
+                      [-77.410881, 39.442343],
+                      [-77.410879, 39.442336],
+                      [-77.410877, 39.442325],
+                      [-77.410875, 39.442314],
+                      [-77.410874, 39.442305],
+                      [-77.410873, 39.442298],
+                      [-77.410871, 39.442286],
+                      [-77.410869, 39.442276],
+                      [-77.410867, 39.442265],
+                      [-77.410866, 39.442256],
+                      [-77.410864, 39.442249],
+                      [-77.410862, 39.442238],
+                      [-77.410861, 39.442227],
+                      [-77.410859, 39.442216],
+                      [-77.410858, 39.442208],
+                      [-77.410856, 39.4422],
+                      [-77.410854, 39.442189],
+                      [-77.410853, 39.44218],
+                      [-77.410851, 39.442173],
+                      [-77.410849, 39.442162],
+                      [-77.410848, 39.442153],
+                      [-77.410846, 39.442146],
+                      [-77.410844, 39.442135],
+                      [-77.410842, 39.442124],
+                      [-77.41084, 39.442113],
+                      [-77.410839, 39.442105],
+                      [-77.410837, 39.442097],
+                      [-77.410835, 39.442086],
+                      [-77.410834, 39.442077],
+                      [-77.410832, 39.44207],
+                      [-77.41083, 39.442059],
+                      [-77.410828, 39.442048],
+                      [-77.410826, 39.442037],
+                      [-77.410825, 39.442029],
+                      [-77.410821, 39.442008],
+                      [-77.417296, 39.441145],
+                      [-77.415035, 39.435627],
+                      [-77.424321, 39.434964],
+                      [-77.424818, 39.434484],
+                      [-77.424809, 39.434542],
+                      [-77.432092, 39.428608],
+                      [-77.4361, 39.435234],
+                      [-77.437165, 39.437415],
+                      [-77.437169, 39.437422],
+                      [-77.437172, 39.437429],
+                      [-77.437176, 39.437436],
+                      [-77.437179, 39.437443],
+                      [-77.437182, 39.43745],
+                      [-77.437186, 39.437457],
+                      [-77.437189, 39.437464],
+                      [-77.437192, 39.437471],
+                      [-77.437196, 39.437478],
+                      [-77.437199, 39.437485],
+                      [-77.437202, 39.437493],
+                      [-77.437205, 39.4375],
+                      [-77.437209, 39.437507],
+                      [-77.437212, 39.437514],
+                      [-77.437215, 39.437521],
+                      [-77.437218, 39.437528],
+                      [-77.437221, 39.437535],
+                      [-77.437224, 39.437543],
+                      [-77.437228, 39.43755],
+                      [-77.437231, 39.437557],
+                      [-77.437234, 39.437564],
+                      [-77.437237, 39.437571],
+                      [-77.43724, 39.437578],
+                      [-77.437243, 39.437586],
+                      [-77.437246, 39.437593],
+                      [-77.437249, 39.4376],
+                      [-77.437252, 39.437607],
+                      [-77.437255, 39.437614],
+                      [-77.437258, 39.437621],
+                      [-77.43726, 39.437629],
+                      [-77.437263, 39.437636],
+                      [-77.437266, 39.437643],
+                      [-77.437269, 39.43765],
+                      [-77.437272, 39.437658],
+                      [-77.437275, 39.437665],
+                      [-77.437277, 39.437672],
+                      [-77.43728, 39.437679],
+                      [-77.437283, 39.437687],
+                      [-77.437286, 39.437694],
+                      [-77.437288, 39.437701],
+                      [-77.437291, 39.437708],
+                      [-77.437294, 39.437716],
+                      [-77.437296, 39.437723],
+                      [-77.437299, 39.43773],
+                      [-77.437302, 39.437737],
+                      [-77.437304, 39.437745],
+                      [-77.437307, 39.437752],
+                      [-77.437309, 39.437759],
+                      [-77.437312, 39.437766],
+                      [-77.437315, 39.437774],
+                      [-77.437317, 39.437781],
+                      [-77.43732, 39.437788],
+                      [-77.437322, 39.437796],
+                      [-77.437324, 39.437803],
+                      [-77.437327, 39.43781],
+                      [-77.437329, 39.437818],
+                      [-77.437332, 39.437825],
+                      [-77.437334, 39.437832],
+                      [-77.437336, 39.43784],
+                      [-77.437339, 39.437847],
+                      [-77.437341, 39.437854],
+                      [-77.437343, 39.437862],
+                      [-77.437346, 39.437869],
+                      [-77.437348, 39.437876],
+                      [-77.43735, 39.437884],
+                      [-77.437352, 39.437891],
+                      [-77.437354, 39.437898],
+                      [-77.437357, 39.437906],
+                      [-77.437359, 39.437913],
+                      [-77.437361, 39.43792],
+                      [-77.437363, 39.437928],
+                      [-77.437365, 39.437935],
+                      [-77.437367, 39.437943],
+                      [-77.437369, 39.43795],
+                      [-77.437371, 39.437957],
+                      [-77.437373, 39.437965],
+                      [-77.437375, 39.437972],
+                      [-77.437377, 39.437979],
+                      [-77.437379, 39.437987],
+                      [-77.437381, 39.437994],
+                      [-77.437383, 39.438002],
+                      [-77.437385, 39.438009],
+                      [-77.437387, 39.438016],
+                      [-77.437389, 39.438024],
+                      [-77.437391, 39.438031],
+                      [-77.437393, 39.438039],
+                      [-77.437394, 39.438046],
+                      [-77.437396, 39.438054],
+                      [-77.437398, 39.438061],
+                      [-77.4374, 39.438068],
+                      [-77.437401, 39.438076],
+                      [-77.437403, 39.438083],
+                      [-77.437405, 39.438091],
+                      [-77.437406, 39.438098],
+                      [-77.437408, 39.438106],
+                      [-77.43741, 39.438113],
+                      [-77.43741, 39.438121],
+                      [-77.436009, 39.435272],
+                      [-77.434089, 39.435267],
+                      [-77.434032, 39.433526],
+                      [-77.434561, 39.433294],
+                      [-77.434011, 39.432373],
+                      [-77.433241, 39.432384],
+                      [-77.433242, 39.432405],
+                      [-77.432899, 39.43241],
+                      [-77.432899, 39.43239],
+                      [-77.432666, 39.432394],
+                      [-77.432417, 39.432342],
+                      [-77.432927, 39.431622],
+                      [-77.433591, 39.431475],
+                      [-77.433719, 39.431405],
+                      [-77.433276, 39.431075],
+                      [-77.433187, 39.431146],
+                      [-77.432536, 39.430664],
+                      [-77.432402, 39.430759],
+                      [-77.431982, 39.431097],
+                      [-77.431879, 39.431021],
+                      [-77.431665, 39.431192],
+                      [-77.432243, 39.431619],
+                      [-77.429943, 39.433486],
+                      [-77.429833, 39.433407],
+                      [-77.42864, 39.434404],
+                      [-77.428903, 39.434608],
+                      [-77.428924, 39.434591],
+                      [-77.430323, 39.43563],
+                      [-77.430326, 39.435806],
+                      [-77.431697, 39.436774],
+                      [-77.432855, 39.436755],
+                      [-77.433586, 39.43775],
+                      [-77.433671, 39.437714],
+                      [-77.434568, 39.438959],
+                      [-77.435984, 39.438336],
+                      [-77.437394, 39.438401],
+                      [-77.437425, 39.438185],
+                      [-77.437429, 39.438209],
+                      [-77.437433, 39.438233],
+                      [-77.437438, 39.438257],
+                      [-77.437442, 39.438282],
+                      [-77.437445, 39.438306],
+                      [-77.437449, 39.43833],
+                      [-77.437452, 39.438355],
+                      [-77.437455, 39.438379],
+                      [-77.437458, 39.438403],
+                      [-77.437461, 39.438427],
+                      [-77.437463, 39.438452],
+                      [-77.437466, 39.438476],
+                      [-77.437468, 39.438501],
+                      [-77.43747, 39.438525],
+                      [-77.437471, 39.438549],
+                      [-77.437473, 39.438574],
+                      [-77.437474, 39.438598],
+                      [-77.437475, 39.438623],
+                      [-77.437476, 39.438647],
+                      [-77.437477, 39.438671],
+                      [-77.437477, 39.438696],
+                      [-77.437477, 39.43872],
+                      [-77.437477, 39.438745],
+                      [-77.437477, 39.438769],
+                      [-77.437477, 39.438794],
+                      [-77.437476, 39.438818],
+                      [-77.437475, 39.438842],
+                      [-77.437474, 39.438867],
+                      [-77.437473, 39.438891],
+                      [-77.437472, 39.438916],
+                      [-77.43747, 39.43894],
+                      [-77.437468, 39.438964],
+                      [-77.437466, 39.438989],
+                      [-77.437464, 39.439013],
+                      [-77.437461, 39.439037],
+                      [-77.437459, 39.439062],
+                      [-77.437456, 39.439086],
+                      [-77.437453, 39.43911],
+                      [-77.43745, 39.439135],
+                      [-77.437446, 39.439159],
+                      [-77.437442, 39.439183],
+                      [-77.437439, 39.439207],
+                      [-77.437434, 39.439232],
+                      [-77.43743, 39.439256],
+                      [-77.437426, 39.43928],
+                      [-77.437421, 39.439304],
+                      [-77.437416, 39.439328],
+                      [-77.437411, 39.439352],
+                      [-77.437406, 39.439377],
+                      [-77.4374, 39.439401],
+                      [-77.437394, 39.439425],
+                      [-77.437388, 39.439449],
+                      [-77.437382, 39.439473],
+                      [-77.437376, 39.439496],
+                      [-77.437369, 39.43952],
+                      [-77.437363, 39.439544],
+                      [-77.437356, 39.439568],
+                      [-77.437349, 39.439592],
+                      [-77.437341, 39.439616],
+                      [-77.437334, 39.439639],
+                      [-77.437326, 39.439663],
+                      [-77.437318, 39.439687],
+                      [-77.43731, 39.43971],
+                      [-77.437302, 39.439734],
+                      [-77.437293, 39.439757],
+                      [-77.437284, 39.439781],
+                      [-77.437275, 39.439804],
+                      [-77.437266, 39.439828],
+                      [-77.437257, 39.439851],
+                      [-77.437247, 39.439874],
+                      [-77.437238, 39.439897],
+                      [-77.437228, 39.439921],
+                      [-77.437218, 39.439944],
+                      [-77.437207, 39.439967],
+                      [-77.437197, 39.43999],
+                      [-77.437186, 39.440013],
+                      [-77.437175, 39.440036],
+                      [-77.437164, 39.440059],
+                      [-77.437153, 39.440081],
+                      [-77.437141, 39.440104],
+                      [-77.43713, 39.440127],
+                      [-77.437118, 39.440149],
+                      [-77.437106, 39.440172],
+                      [-77.437093, 39.440194],
+                      [-77.437081, 39.440217],
+                      [-77.437068, 39.440239],
+                      [-77.437056, 39.440262],
+                      [-77.437043, 39.440284],
+                      [-77.437029, 39.440306],
+                      [-77.437016, 39.440328],
+                      [-77.437002, 39.44035],
+                      [-77.436989, 39.440372],
+                      [-77.436975, 39.440394],
+                      [-77.436961, 39.440416],
+                      [-77.436946, 39.440438],
+                      [-77.436932, 39.440459],
+                      [-77.436917, 39.440481],
+                      [-77.436902, 39.440503],
+                      [-77.436887, 39.440524],
+                      [-77.436051, 39.441708],
+                      [-77.436025, 39.441745],
+                      [-77.436, 39.441782],
+                      [-77.435974, 39.441819],
+                      [-77.435948, 39.441856],
+                      [-77.435923, 39.441893],
+                      [-77.435898, 39.441931],
+                      [-77.435873, 39.441968],
+                      [-77.435848, 39.442005],
+                      [-77.435823, 39.442043],
+                      [-77.435799, 39.44208],
+                      [-77.435774, 39.442118],
+                      [-77.43575, 39.442156],
+                      [-77.435726, 39.442193],
+                      [-77.435702, 39.442231],
+                      [-77.435678, 39.442269],
+                      [-77.435655, 39.442307],
+                      [-77.435631, 39.442345],
+                      [-77.435608, 39.442383],
+                      [-77.435585, 39.442421],
+                      [-77.435562, 39.442459],
+                      [-77.435539, 39.442497],
+                      [-77.435517, 39.442536],
+                      [-77.435494, 39.442574],
+                      [-77.435472, 39.442612],
+                      [-77.43545, 39.442651],
+                      [-77.435428, 39.442689],
+                      [-77.435406, 39.442728],
+                      [-77.435385, 39.442766],
+                      [-77.435363, 39.442805],
+                      [-77.435342, 39.442844],
+                      [-77.435321, 39.442883],
+                      [-77.4353, 39.442921],
+                      [-77.435279, 39.44296],
+                      [-77.435258, 39.442999],
+                      [-77.435238, 39.443038],
+                      [-77.435218, 39.443077],
+                      [-77.435197, 39.443116],
+                      [-77.435177, 39.443155],
+                      [-77.435158, 39.443195],
+                      [-77.435138, 39.443234],
+                      [-77.435119, 39.443273],
+                      [-77.435099, 39.443312],
+                      [-77.43508, 39.443352],
+                      [-77.435061, 39.443391],
+                      [-77.435042, 39.443431],
+                      [-77.435024, 39.44347],
+                      [-77.435005, 39.44351],
+                      [-77.434987, 39.44355],
+                      [-77.434969, 39.443589],
+                      [-77.434951, 39.443629],
+                      [-77.434933, 39.443669],
+                      [-77.434916, 39.443709],
+                      [-77.434898, 39.443748],
+                      [-77.434881, 39.443788],
+                      [-77.434864, 39.443828],
+                      [-77.434847, 39.443868],
+                      [-77.43483, 39.443908],
+                      [-77.434814, 39.443948],
+                      [-77.434797, 39.443988],
+                      [-77.434781, 39.444029],
+                      [-77.434765, 39.444069],
+                      [-77.434749, 39.444109],
+                      [-77.434734, 39.444149],
+                      [-77.434718, 39.44419],
+                      [-77.434703, 39.44423],
+                      [-77.434687, 39.44427],
+                      [-77.434672, 39.444311],
+                      [-77.434658, 39.444351],
+                      [-77.434643, 39.444392],
+                      [-77.434628, 39.444432],
+                      [-77.434614, 39.444473],
+                      [-77.4346, 39.444514],
+                      [-77.434586, 39.444554],
+                      [-77.434572, 39.444595],
+                      [-77.434558, 39.444636],
+                      [-77.434545, 39.444677],
+                      [-77.434532, 39.444717],
+                      [-77.434519, 39.444758],
+                      [-77.434506, 39.444799],
+                      [-77.434493, 39.44484],
+                      [-77.43448, 39.444881],
+                      [-77.434468, 39.444922],
+                      [-77.434456, 39.444963],
+                      [-77.434444, 39.445004],
+                      [-77.434432, 39.445045],
+                      [-77.43442, 39.445086],
+                      [-77.434409, 39.445127],
+                      [-77.434397, 39.445168],
+                      [-77.434386, 39.44521],
+                      [-77.434375, 39.445251],
+                      [-77.434364, 39.445292],
+                      [-77.434354, 39.445333],
+                      [-77.434343, 39.445375],
+                      [-77.434333, 39.445416],
+                      [-77.434323, 39.445457],
+                      [-77.434313, 39.445499],
+                      [-77.434303, 39.44554],
+                      [-77.434293, 39.445581],
+                      [-77.434283, 39.445623],
+                      [-77.432803, 39.44542],
+                      [-77.432463, 39.447853],
+                      [-77.431211, 39.447748],
+                      [-77.431419, 39.44868],
+                      [-77.431526, 39.449053],
+                      [-77.431782, 39.449598],
+                      [-77.431579, 39.449915],
+                      [-77.431137, 39.449831],
+                      [-77.427982, 39.448985],
+                      [-77.426388, 39.448979],
+                      [-77.423945, 39.448185],
+                      [-77.412819, 39.450398],
+                      [-77.412579, 39.450339],
+                      [-77.412406, 39.45019],
+                      [-77.412398, 39.450183],
+                      [-77.412389, 39.450175],
+                      [-77.412381, 39.450168],
+                      [-77.412373, 39.45016],
+                      [-77.412364, 39.450153],
+                      [-77.412356, 39.450145],
+                      [-77.412348, 39.450138],
+                      [-77.41234, 39.45013],
+                      [-77.412332, 39.450122],
+                      [-77.412324, 39.450115],
+                      [-77.412316, 39.450107],
+                      [-77.412308, 39.450099],
+                      [-77.412301, 39.450091],
+                      [-77.412293, 39.450083],
+                      [-77.412285, 39.450075],
+                      [-77.412278, 39.450067],
+                      [-77.41227, 39.450059],
+                      [-77.412263, 39.450051],
+                      [-77.412256, 39.450043],
+                      [-77.412248, 39.450035],
+                      [-77.412241, 39.450027],
+                      [-77.412234, 39.450019],
+                      [-77.412227, 39.450011],
+                      [-77.41222, 39.450003],
+                      [-77.412213, 39.449994],
+                      [-77.412206, 39.449986],
+                      [-77.412199, 39.449978],
+                      [-77.412192, 39.449969],
+                      [-77.412186, 39.449961],
+                      [-77.412179, 39.449953],
+                      [-77.412172, 39.449944],
+                      [-77.412166, 39.449936],
+                      [-77.41216, 39.449927],
+                      [-77.412153, 39.449919],
+                      [-77.412147, 39.44991],
+                      [-77.412141, 39.449901],
+                      [-77.412135, 39.449893],
+                      [-77.412129, 39.449884],
+                      [-77.412123, 39.449875],
+                      [-77.412117, 39.449867],
+                      [-77.412111, 39.449858],
+                      [-77.412105, 39.449849],
+                      [-77.412099, 39.44984],
+                      [-77.412094, 39.449831],
+                      [-77.412088, 39.449822],
+                      [-77.412083, 39.449814],
+                      [-77.412077, 39.449805],
+                      [-77.412072, 39.449796],
+                      [-77.412067, 39.449787],
+                      [-77.412061, 39.449778],
+                      [-77.412056, 39.449769],
+                      [-77.412051, 39.44976],
+                      [-77.412046, 39.449751],
+                      [-77.412041, 39.449741],
+                      [-77.412036, 39.449732],
+                      [-77.412032, 39.449723],
+                      [-77.412027, 39.449714],
+                      [-77.412022, 39.449705],
+                      [-77.412018, 39.449696],
+                      [-77.412013, 39.449686],
+                      [-77.412009, 39.449677],
+                      [-77.412005, 39.449668],
+                      [-77.412, 39.449658],
+                      [-77.411996, 39.449649],
+                      [-77.411992, 39.44964],
+                      [-77.411988, 39.44963],
+                      [-77.411984, 39.449621],
+                      [-77.41198, 39.449612],
+                      [-77.411976, 39.449602],
+                      [-77.411973, 39.449593],
+                      [-77.411969, 39.449583],
+                      [-77.411966, 39.449574],
+                      [-77.411962, 39.449564],
+                      [-77.411959, 39.449555],
+                      [-77.411955, 39.449545],
+                      [-77.411952, 39.449536],
+                      [-77.411949, 39.449526],
+                      [-77.411946, 39.449517],
+                      [-77.411943, 39.449507],
+                      [-77.41194, 39.449498],
+                      [-77.411937, 39.449488],
+                      [-77.411934, 39.449478],
+                      [-77.411931, 39.449469],
+                      [-77.411929, 39.449459],
+                      [-77.411926, 39.449449],
+                      [-77.411924, 39.44944],
+                      [-77.411921, 39.44943],
+                      [-77.411919, 39.44942],
+                      [-77.411917, 39.449411],
+                      [-77.411915, 39.449401],
+                      [-77.411913, 39.449391],
+                      [-77.411911, 39.449381],
+                      [-77.411909, 39.449372],
+                      [-77.411907, 39.449362],
+                      [-77.411905, 39.449352],
+                      [-77.411903, 39.449342],
+                      [-77.411902, 39.449332],
+                      [-77.4119, 39.449323],
+                      [-77.411899, 39.449313]
+                    ]
+                  ],
+                  "type": "Polygon"
+                },
+                "properties": {
+                  "agency": "DOD",
+                  "ceiling": 400,
+                  "ceiling_ref": "AGL",
+                  "ceiling_uom": "FT",
+                  "contact_info": "LTC Jerry Lewis / 404 305-6916   Emergency: EOC 301-619-8547",
+                  "name": "Fort Detrick, Fort Detrick, MD 4"
+                },
+                "type": "Feature"
+              }
+            ],
+            "type": "FeatureCollection"
+          }
+        },
+        "properties": {
+          "found": {
+            "title": "Found",
+            "type": "object"
+          }
+        },
+        "required": ["found"],
+        "title": "SSADistanceResponse",
+        "type": "object"
+      },
+      "SSAPolyResponse": {
+        "example": {
+          "found": {
+            "features": [
+              {
+                "geometry": {
+                  "coordinates": [
+                    [
+                      [-120.844923, 35.202822],
+                      [-120.844495, 35.203913],
+                      [-120.844441, 35.204051],
+                      [-120.844459, 35.204136],
+                      [-120.844558, 35.204255],
+                      [-120.844696, 35.2043],
+                      [-120.844898, 35.204332],
+                      [-120.845022, 35.204476],
+                      [-120.845229, 35.204477],
+                      [-120.845278, 35.204569],
+                      [-120.845373, 35.20458],
+                      [-120.845555, 35.204578],
+                      [-120.845749, 35.204566],
+                      [-120.845833, 35.204652],
+                      [-120.845964, 35.204662],
+                      [-120.846146, 35.20465],
+                      [-120.846405, 35.20472],
+                      [-120.846608, 35.204735],
+                      [-120.846985, 35.204822],
+                      [-120.847445, 35.204949],
+                      [-120.8477, 35.20493],
+                      [-120.847824, 35.204829],
+                      [-120.847994, 35.204804],
+                      [-120.848188, 35.204849],
+                      [-120.848223, 35.204902],
+                      [-120.848191, 35.204969],
+                      [-120.848641, 35.205246],
+                      [-120.848726, 35.205245],
+                      [-120.848858, 35.20525],
+                      [-120.848923, 35.205394],
+                      [-120.848968, 35.205559],
+                      [-120.849183, 35.20573],
+                      [-120.849242, 35.206006],
+                      [-120.849446, 35.206322],
+                      [-120.849747, 35.206378],
+                      [-120.850106, 35.206341],
+                      [-120.850311, 35.20621],
+                      [-120.850384, 35.2059],
+                      [-120.850556, 35.205784],
+                      [-120.850759, 35.205772],
+                      [-120.850852, 35.20586],
+                      [-120.850956, 35.205841],
+                      [-120.85102, 35.205806],
+                      [-120.851013, 35.20572],
+                      [-120.851085, 35.205693],
+                      [-120.851252, 35.205795],
+                      [-120.851352, 35.205789],
+                      [-120.851411, 35.205774],
+                      [-120.851454, 35.205797],
+                      [-120.851472, 35.205829],
+                      [-120.851558, 35.205901],
+                      [-120.851652, 35.205883],
+                      [-120.851723, 35.205782],
+                      [-120.85197, 35.205849],
+                      [-120.852214, 35.20588],
+                      [-120.852432, 35.205787],
+                      [-120.852763, 35.205844],
+                      [-120.852905, 35.205843],
+                      [-120.853261, 35.205799],
+                      [-120.853644, 35.205862],
+                      [-120.854651, 35.20593],
+                      [-120.856174, 35.206623],
+                      [-120.857395, 35.207859],
+                      [-120.857656, 35.208286],
+                      [-120.857479, 35.208726],
+                      [-120.856995, 35.208755],
+                      [-120.856382, 35.209128],
+                      [-120.856114, 35.209604],
+                      [-120.857863, 35.212541],
+                      [-120.858122, 35.212478],
+                      [-120.858864, 35.212973],
+                      [-120.859637, 35.213106],
+                      [-120.860157, 35.213001],
+                      [-120.860381, 35.212558],
+                      [-120.860875, 35.212704],
+                      [-120.860701, 35.212923],
+                      [-120.860782, 35.213032],
+                      [-120.860916, 35.213275],
+                      [-120.860986, 35.213625],
+                      [-120.860838, 35.213725],
+                      [-120.860696, 35.213956],
+                      [-120.86041, 35.214346],
+                      [-120.859901, 35.214791],
+                      [-120.859091, 35.214976],
+                      [-120.858962, 35.215133],
+                      [-120.858792, 35.21549],
+                      [-120.858946, 35.215942],
+                      [-120.858344, 35.216044],
+                      [-120.858794, 35.217125],
+                      [-120.858046, 35.217215],
+                      [-120.856961, 35.216964],
+                      [-120.856252, 35.216496],
+                      [-120.854243, 35.21752],
+                      [-120.853982, 35.218077],
+                      [-120.85381, 35.218859],
+                      [-120.852784, 35.219517],
+                      [-120.852144, 35.219866],
+                      [-120.851835, 35.220352],
+                      [-120.851276, 35.220211],
+                      [-120.850353, 35.220181],
+                      [-120.848941, 35.220801],
+                      [-120.848107, 35.221524],
+                      [-120.847577, 35.221995],
+                      [-120.846817, 35.222679],
+                      [-120.845061, 35.224116],
+                      [-120.844612, 35.223993],
+                      [-120.844739, 35.223051],
+                      [-120.845153, 35.222703],
+                      [-120.844958, 35.222194],
+                      [-120.844386, 35.221057],
+                      [-120.843102, 35.220836],
+                      [-120.841572, 35.220714],
+                      [-120.840315, 35.220595],
+                      [-120.839875, 35.220834],
+                      [-120.839396, 35.220721],
+                      [-120.839121, 35.22048],
+                      [-120.838772, 35.22012],
+                      [-120.837443, 35.219798],
+                      [-120.836659, 35.219609],
+                      [-120.83496, 35.219362],
+                      [-120.834743, 35.219563],
+                      [-120.8344, 35.219818],
+                      [-120.833868, 35.219696],
+                      [-120.833522, 35.219448],
+                      [-120.833052, 35.219161],
+                      [-120.832572, 35.219186],
+                      [-120.833293, 35.218424],
+                      [-120.834337, 35.218275],
+                      [-120.833795, 35.216901],
+                      [-120.833727, 35.216515],
+                      [-120.833775, 35.216267],
+                      [-120.834221, 35.216162],
+                      [-120.834988, 35.2164],
+                      [-120.835704, 35.215627],
+                      [-120.836301, 35.215173],
+                      [-120.837709, 35.213643],
+                      [-120.836618, 35.212321],
+                      [-120.836012, 35.210256],
+                      [-120.835547, 35.208485],
+                      [-120.835778, 35.207723],
+                      [-120.836304, 35.206867],
+                      [-120.839131, 35.205563],
+                      [-120.840976, 35.204488],
+                      [-120.842968, 35.203632],
+                      [-120.843138, 35.203149],
+                      [-120.843344, 35.202315],
+                      [-120.843838, 35.202338],
+                      [-120.844529, 35.202528],
+                      [-120.844923, 35.202822]
+                    ]
+                  ],
+                  "type": "Polygon"
+                },
+                "properties": {
+                  "agency": "DOE",
+                  "ceiling": 400,
+                  "ceiling_ref": "AGL",
+                  "ceiling_uom": "FT",
+                  "contact_info": "SoLita M. Greene, CISM,Director, NE-32 /D-430,301-903-5006 Office,202-740-1176 Cell,NESAN: Solita.greene@nesan.nnsahq.gov",
+                  "name": "Diablo Canyon Nuclear Power Plant, Pacific Gas & Electric (PG&E) Diablo Canyon Nuclear Power Plant"
+                },
+                "type": "Feature"
+              }
+            ],
+            "type": "FeatureCollection"
+          }
+        },
+        "properties": {
+          "found": {
+            "title": "Found",
+            "type": "object"
+          }
+        },
+        "required": ["found"],
+        "title": "SSAPolyResponse",
+        "type": "object"
+      },
+      "SSARouteResponse": {
+        "example": {
+          "found": {
+            "features": [
+              {
+                "geometry": {
+                  "coordinates": [
+                    [
+                      [-110.790065, 32.161849],
+                      [-110.790097, 32.122995],
+                      [-110.794045, 32.123017],
+                      [-110.794088, 32.123017],
+                      [-110.794131, 32.123012],
+                      [-110.794172, 32.123],
+                      [-110.794211, 32.122983],
+                      [-110.794247, 32.122961],
+                      [-110.79428, 32.122933],
+                      [-110.794309, 32.122901],
+                      [-110.794333, 32.122866],
+                      [-110.794352, 32.122827],
+                      [-110.794365, 32.122787],
+                      [-110.794372, 32.122744],
+                      [-110.794389, 32.119389],
+                      [-110.798014, 32.119406],
+                      [-110.798008, 32.122767],
+                      [-110.798015, 32.122809],
+                      [-110.798028, 32.12285],
+                      [-110.798046, 32.122888],
+                      [-110.798069, 32.122924],
+                      [-110.798098, 32.122955],
+                      [-110.79813, 32.122983],
+                      [-110.798166, 32.123006],
+                      [-110.798205, 32.123023],
+                      [-110.798246, 32.123035],
+                      [-110.798288, 32.123041],
+                      [-110.798331, 32.123041],
+                      [-110.802292, 32.123063],
+                      [-110.802313, 32.125991],
+                      [-110.80232, 32.126032],
+                      [-110.802333, 32.126073],
+                      [-110.802351, 32.126111],
+                      [-110.802375, 32.126146],
+                      [-110.802403, 32.126178],
+                      [-110.802435, 32.126205],
+                      [-110.802471, 32.126227],
+                      [-110.80251, 32.126245],
+                      [-110.80255, 32.126257],
+                      [-110.802592, 32.126262],
+                      [-110.802635, 32.126262],
+                      [-110.806804, 32.126292],
+                      [-110.817439, 32.132843],
+                      [-110.817484, 32.132866],
+                      [-110.817532, 32.132883],
+                      [-110.817581, 32.132893],
+                      [-110.817632, 32.132896],
+                      [-110.821861, 32.132882],
+                      [-110.822069, 32.13301],
+                      [-110.822114, 32.133033],
+                      [-110.822161, 32.13305],
+                      [-110.82221, 32.13306],
+                      [-110.822261, 32.133063],
+                      [-110.823969, 32.133067],
+                      [-110.83104, 32.133079],
+                      [-110.831088, 32.133078],
+                      [-110.831136, 32.133069],
+                      [-110.831181, 32.133054],
+                      [-110.831224, 32.133032],
+                      [-110.831263, 32.133004],
+                      [-110.831298, 32.13297],
+                      [-110.831327, 32.132932],
+                      [-110.83135, 32.13289],
+                      [-110.832214, 32.130746],
+                      [-110.832205, 32.132808],
+                      [-110.832202, 32.133732],
+                      [-110.832194, 32.135544],
+                      [-110.832201, 32.135586],
+                      [-110.832214, 32.135627],
+                      [-110.832232, 32.135666],
+                      [-110.832256, 32.135702],
+                      [-110.832284, 32.135734],
+                      [-110.832317, 32.135761],
+                      [-110.832353, 32.135784],
+                      [-110.832392, 32.135801],
+                      [-110.832433, 32.135813],
+                      [-110.832476, 32.135819],
+                      [-110.832518, 32.135819],
+                      [-110.833245, 32.13582],
+                      [-110.83326, 32.137362],
+                      [-110.833268, 32.137404],
+                      [-110.833281, 32.137444],
+                      [-110.833299, 32.137483],
+                      [-110.833323, 32.137518],
+                      [-110.833352, 32.137549],
+                      [-110.833384, 32.137577],
+                      [-110.83342, 32.137599],
+                      [-110.833459, 32.137616],
+                      [-110.8335, 32.137628],
+                      [-110.833542, 32.137633],
+                      [-110.833585, 32.137633],
+                      [-110.834326, 32.137634],
+                      [-110.834304, 32.140051],
+                      [-110.834308, 32.140096],
+                      [-110.834309, 32.140101],
+                      [-110.834394, 32.1405],
+                      [-110.834404, 32.140535],
+                      [-110.83442, 32.140569],
+                      [-110.83444, 32.1406],
+                      [-110.834464, 32.140628],
+                      [-110.834491, 32.140652],
+                      [-110.834522, 32.140673],
+                      [-110.839566, 32.14377],
+                      [-110.840152, 32.14413],
+                      [-110.840304, 32.144236],
+                      [-110.840267, 32.162002],
+                      [-110.81576, 32.161981],
+                      [-110.797973, 32.161898],
+                      [-110.790065, 32.161849]
+                    ]
+                  ],
+                  "type": "Polygon"
+                },
+                "properties": {
+                  "agency": "DOD",
+                  "ceiling": 400,
+                  "ceiling_ref": "AGL",
+                  "ceiling_uom": "FT",
+                  "contact_info": "CP: 520-228-3900 or Airspace Mgr:  520-228-4680     Emergency: Command Post: 520-228-3900",
+                  "name": "Davis Monthan, Installation 1"
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [
+                    [
+                      [-110.856007, 32.176938],
+                      [-110.855965, 32.176932],
+                      [-110.855922, 32.176932],
+                      [-110.841452, 32.176873],
+                      [-110.841349, 32.162275],
+                      [-110.841118, 32.159671],
+                      [-110.841351, 32.158695],
+                      [-110.841355, 32.144869],
+                      [-110.853367, 32.152243],
+                      [-110.85341, 32.152266],
+                      [-110.853457, 32.152282],
+                      [-110.853505, 32.152292],
+                      [-110.853554, 32.152296],
+                      [-110.855959, 32.152322],
+                      [-110.856002, 32.152322],
+                      [-110.856045, 32.152317],
+                      [-110.856086, 32.152306],
+                      [-110.856125, 32.152289],
+                      [-110.856162, 32.152267],
+                      [-110.856195, 32.15224],
+                      [-110.856224, 32.152208],
+                      [-110.856248, 32.152173],
+                      [-110.856267, 32.152134],
+                      [-110.856281, 32.152093],
+                      [-110.856288, 32.152051],
+                      [-110.856313, 32.150182],
+                      [-110.857933, 32.150204],
+                      [-110.857976, 32.150205],
+                      [-110.858019, 32.1502],
+                      [-110.85806, 32.150188],
+                      [-110.8581, 32.150171],
+                      [-110.858137, 32.150149],
+                      [-110.85817, 32.150121],
+                      [-110.858199, 32.150089],
+                      [-110.858223, 32.150054],
+                      [-110.858242, 32.150015],
+                      [-110.858255, 32.149974],
+                      [-110.858263, 32.149931],
+                      [-110.858283, 32.142051],
+                      [-110.874691, 32.142051],
+                      [-110.874774, 32.148668],
+                      [-110.874778, 32.148704],
+                      [-110.874787, 32.14874],
+                      [-110.874802, 32.148774],
+                      [-110.874821, 32.148806],
+                      [-110.874844, 32.148835],
+                      [-110.874871, 32.14886],
+                      [-110.876746, 32.150414],
+                      [-110.876961, 32.150592],
+                      [-110.877199, 32.150811],
+                      [-110.878131, 32.151691],
+                      [-110.879004, 32.152515],
+                      [-110.879022, 32.152531],
+                      [-110.880309, 32.153558],
+                      [-110.881221, 32.154273],
+                      [-110.882121, 32.155112],
+                      [-110.883251, 32.156149],
+                      [-110.884382, 32.157836],
+                      [-110.884404, 32.157865],
+                      [-110.884429, 32.157889],
+                      [-110.886635, 32.15986],
+                      [-110.886645, 32.159868],
+                      [-110.888631, 32.161494],
+                      [-110.890791, 32.163246],
+                      [-110.890831, 32.163273],
+                      [-110.890875, 32.163295],
+                      [-110.890921, 32.16331],
+                      [-110.890968, 32.16332],
+                      [-110.891017, 32.163322],
+                      [-110.891701, 32.163322],
+                      [-110.891824, 32.163322],
+                      [-110.891858, 32.163348],
+                      [-110.891895, 32.16337],
+                      [-110.891934, 32.163388],
+                      [-110.891976, 32.1634],
+                      [-110.892018, 32.163408],
+                      [-110.892061, 32.16341],
+                      [-110.896036, 32.16343],
+                      [-110.896052, 32.164653],
+                      [-110.896112, 32.167649],
+                      [-110.89612, 32.167695],
+                      [-110.896136, 32.167739],
+                      [-110.896158, 32.167779],
+                      [-110.896186, 32.167817],
+                      [-110.896219, 32.167849],
+                      [-110.896257, 32.167876],
+                      [-110.896299, 32.167896],
+                      [-110.896343, 32.167911],
+                      [-110.896389, 32.167918],
+                      [-110.896435, 32.167918],
+                      [-110.897058, 32.16792],
+                      [-110.897096, 32.169193],
+                      [-110.897105, 32.169238],
+                      [-110.897121, 32.169281],
+                      [-110.897143, 32.169322],
+                      [-110.897171, 32.169359],
+                      [-110.897205, 32.169391],
+                      [-110.897242, 32.169417],
+                      [-110.897284, 32.169438],
+                      [-110.897328, 32.169452],
+                      [-110.897374, 32.169459],
+                      [-110.89742, 32.169459],
+                      [-110.898513, 32.169462],
+                      [-110.898535, 32.170568],
+                      [-110.898539, 32.170607],
+                      [-110.89855, 32.170645],
+                      [-110.898566, 32.170681],
+                      [-110.898588, 32.170714],
+                      [-110.898615, 32.170743],
+                      [-110.900549, 32.172615],
+                      [-110.90056, 32.172624],
+                      [-110.902688, 32.1745],
+                      [-110.902722, 32.174526],
+                      [-110.902759, 32.174547],
+                      [-110.902798, 32.174564],
+                      [-110.902838, 32.174576],
+                      [-110.90288, 32.174583],
+                      [-110.902923, 32.174585],
+                      [-110.904715, 32.174587],
+                      [-110.904725, 32.176186],
+                      [-110.904728, 32.176222],
+                      [-110.904737, 32.176257],
+                      [-110.90475, 32.17629],
+                      [-110.904768, 32.176321],
+                      [-110.90479, 32.176349],
+                      [-110.904815, 32.176374],
+                      [-110.906927, 32.178223],
+                      [-110.906968, 32.178253],
+                      [-110.907012, 32.178277],
+                      [-110.90706, 32.178294],
+                      [-110.907109, 32.178304],
+                      [-110.907159, 32.178307],
+                      [-110.906584, 32.179038],
+                      [-110.90595, 32.180054],
+                      [-110.905744, 32.181354],
+                      [-110.905902, 32.182512],
+                      [-110.906501, 32.183528],
+                      [-110.907027, 32.183934],
+                      [-110.907259, 32.185133],
+                      [-110.907368, 32.1859],
+                      [-110.90745, 32.186703],
+                      [-110.907523, 32.187403],
+                      [-110.907429, 32.187995],
+                      [-110.907265, 32.188555],
+                      [-110.907058, 32.189109],
+                      [-110.906845, 32.189529],
+                      [-110.906546, 32.189535],
+                      [-110.905852, 32.189547],
+                      [-110.904988, 32.189608],
+                      [-110.904245, 32.189718],
+                      [-110.903703, 32.19004],
+                      [-110.903278, 32.190445],
+                      [-110.90184, 32.192774],
+                      [-110.901232, 32.193303],
+                      [-110.900525, 32.193589],
+                      [-110.89848, 32.194216],
+                      [-110.896093, 32.194813],
+                      [-110.893672, 32.194831],
+                      [-110.892638, 32.194813],
+                      [-110.887564, 32.194772],
+                      [-110.886018, 32.194761],
+                      [-110.885641, 32.194748],
+                      [-110.885141, 32.194704],
+                      [-110.88473, 32.194646],
+                      [-110.884282, 32.194558],
+                      [-110.883923, 32.194468],
+                      [-110.883535, 32.194351],
+                      [-110.883253, 32.194252],
+                      [-110.882935, 32.194126],
+                      [-110.882662, 32.194005],
+                      [-110.882226, 32.193784],
+                      [-110.881585, 32.193432],
+                      [-110.880868, 32.193043],
+                      [-110.880423, 32.192803],
+                      [-110.880141, 32.192655],
+                      [-110.880133, 32.192651],
+                      [-110.880127, 32.192648],
+                      [-110.879798, 32.192495],
+                      [-110.879782, 32.192488],
+                      [-110.879405, 32.192334],
+                      [-110.879388, 32.192328],
+                      [-110.879042, 32.192206],
+                      [-110.879033, 32.192204],
+                      [-110.879027, 32.192202],
+                      [-110.878714, 32.192107],
+                      [-110.878698, 32.192102],
+                      [-110.878339, 32.19201],
+                      [-110.878323, 32.192006],
+                      [-110.877995, 32.191937],
+                      [-110.877983, 32.191935],
+                      [-110.8777, 32.191886],
+                      [-110.877688, 32.191884],
+                      [-110.877274, 32.191826],
+                      [-110.877236, 32.191823],
+                      [-110.876629, 32.191799],
+                      [-110.876618, 32.191799],
+                      [-110.875527, 32.191759],
+                      [-110.873669, 32.191637],
+                      [-110.861886, 32.191601],
+                      [-110.85992, 32.191594],
+                      [-110.858501, 32.191455],
+                      [-110.858434, 32.182758],
+                      [-110.858399, 32.180825],
+                      [-110.85839, 32.18078],
+                      [-110.858375, 32.180736],
+                      [-110.858353, 32.180695],
+                      [-110.858325, 32.180658],
+                      [-110.858292, 32.180626],
+                      [-110.858254, 32.180599],
+                      [-110.858212, 32.180578],
+                      [-110.858168, 32.180564],
+                      [-110.858122, 32.180557],
+                      [-110.858076, 32.180556],
+                      [-110.856203, 32.180545],
+                      [-110.856245, 32.177208],
+                      [-110.856238, 32.177166],
+                      [-110.856226, 32.177125],
+                      [-110.856208, 32.177086],
+                      [-110.856184, 32.17705],
+                      [-110.856156, 32.177018],
+                      [-110.856124, 32.17699],
+                      [-110.856087, 32.176967],
+                      [-110.856048, 32.176949],
+                      [-110.856007, 32.176938]
+                    ]
+                  ],
+                  "type": "Polygon"
+                },
+                "properties": {
+                  "agency": "DOD",
+                  "ceiling": 400,
+                  "ceiling_ref": "AGL",
+                  "ceiling_uom": "FT",
+                  "contact_info": "CP: 520-228-3900 or Airspace Mgr:  520-228-4680     Emergency: Command Post: 520-228-3900",
+                  "name": "Davis Monthan, Installation 2"
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [
+                    [
+                      [-110.874859, 32.075955],
+                      [-110.874953, 32.08957],
+                      [-110.858392, 32.089548],
+                      [-110.858273, 32.07917],
+                      [-110.858244, 32.07591],
+                      [-110.871487, 32.075907],
+                      [-110.874859, 32.075955]
+                    ]
+                  ],
+                  "type": "Polygon"
+                },
+                "properties": {
+                  "agency": "DOJ",
+                  "ceiling": 400,
+                  "ceiling_ref": "AGL",
+                  "ceiling_uom": "FT",
+                  "contact_info": "Control Center (520)663-5000",
+                  "name": "Tucson, USP Tucson"
+                },
+                "type": "Feature"
+              }
+            ],
+            "type": "FeatureCollection"
+          }
+        },
+        "properties": {
+          "found": {
+            "title": "Found",
+            "type": "object"
+          }
+        },
+        "required": ["found"],
+        "title": "SSARouteResponse",
+        "type": "object"
+      },
+      "UOAsByDistance": {
+        "description": "Geometry-defining arguments for point/distance requests",
+        "example": {
+          "distance": 25000,
+          "latitude": 36.36,
+          "longitude": -94.07
+        },
+        "properties": {
+          "distance": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Distance"
+          },
+          "latitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Latitude"
+          },
+          "longitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Longitude"
+          }
+        },
+        "required": ["longitude", "latitude", "distance"],
+        "title": "UOAsByDistance",
+        "type": "object"
+      },
+      "UOAsByPolygon": {
+        "description": "Geometry-defining arguments for polygon requests",
+        "example": {
+          "poly": {
+            "coordinates": [
+              [
+                [-84.31182861328125, 39.47171528483254],
+                [-83.9959716796875, 39.47224533091448],
+                [-84.07218933105469, 39.627374847167204],
+                [-84.31182861328125, 39.47171528483254]
+              ]
+            ],
+            "type": "Polygon"
+          }
+        },
+        "properties": {
+          "poly": {
+            "title": "Poly",
+            "type": "object"
+          }
+        },
+        "required": ["poly"],
+        "title": "UOAsByPolygon",
+        "type": "object"
+      },
+      "UOAsByRoute": {
+        "description": "Geometry-defining arguments for along-route requests",
+        "example": {
+          "route": {
+            "coordinates": [
+              [-89.428019, 38.693705],
+              [-89.256689, 38.604771],
+              [-89.331396, 38.388092]
+            ],
+            "type": "LineString"
+          }
+        },
+        "properties": {
+          "route": {
+            "title": "Route",
+            "type": "object"
+          }
+        },
+        "required": ["route"],
+        "title": "UOAsByRoute",
+        "type": "object"
+      },
+      "UOAsDistanceResponse": {
+        "example": {
+          "found": {
+            "features": [
+              {
+                "geometry": {
+                  "coordinates": [
+                    [
+                      [-94.032778, 36.259444],
+                      [-94.0525, 36.261111],
+                      [-94.101944, 36.220833],
+                      [-94.252778, 36.226389],
+                      [-94.333333, 36.231944],
+                      [-94.357222, 36.185],
+                      [-94.358056, 36.137778],
+                      [-94.514722, 36.136667],
+                      [-94.538889, 36.175],
+                      [-94.690278, 36.176667],
+                      [-94.690278, 36.161944],
+                      [-94.782778, 36.161667],
+                      [-94.889722, 36.060556],
+                      [-94.893333, 35.901667],
+                      [-94.921389, 35.813889],
+                      [-94.99, 35.639167],
+                      [-94.815278, 35.625556],
+                      [-94.737222, 35.625],
+                      [-94.737222, 35.639167],
+                      [-94.472778, 35.639444],
+                      [-94.490556, 35.743333],
+                      [-94.230833, 35.739444],
+                      [-94.231667, 35.721111],
+                      [-93.955556, 35.685278],
+                      [-93.774167, 35.7425],
+                      [-93.709722, 35.770556],
+                      [-93.572778, 35.765],
+                      [-93.500278, 35.898333],
+                      [-93.538333, 35.911667],
+                      [-93.681667, 35.928889],
+                      [-93.733333, 35.941389],
+                      [-93.746389, 36.004167],
+                      [-93.768889, 36.043333],
+                      [-93.770278, 36.114722],
+                      [-93.799167, 36.188611],
+                      [-93.846667, 36.231389],
+                      [-93.935278, 36.257778],
+                      [-94.020278, 36.255],
+                      [-94.032778, 36.259444]
+                    ]
+                  ],
+                  "type": "Polygon"
+                },
+                "properties": {
+                  "endDateTime": "2023-05-06T23:59:00.000Z",
+                  "startDateTime": "2021-10-29T20:09:00.000Z",
+                  "text": "AIRSPACE UAS WI AN AREA DEFINED AS 361534N0940158W (6NM NE ASG) TO 361540N0940309W (5.1NM NE ASG) TO 361315N0940607W (2.4NM NE ASG) TO 361335N0941510W (4.6NM SE XNA) TO 361355N0942000W (3.7NM SSW XNA) TO 361106N0942126W (5.8NM SW XNA) TO 360816N0942129W (7.3NM SE SLG) TO 360812N0943053W (3.1NM SSW SLG) TO 361030N0943220W (2.4NM SW SLG) TO 361036N0944125W (9.3NM WSW SLG) TO 360943N0944125W (9.3NM WSW SLG) TO 360942N0944658W (13.6NM WSW SLG) TO 360338N0945323W (8.8NM NE TQH) TO 355406N0945336W (5.3NM ESE TQH) TO 354850N0945517W (5NM NEN 44M) TO 353821N0945924W (5.1NM SW 44M) TO 353732N0944855W (7.9NM SE 44M) TO 353730N0944414W (8.9NM SW 1PP) TO 353821N0944414W (7.9NM SW 1PP) TO 353822N0942822W (10.8NM SE 1PP) TO 354436N0942926W (7.3NM ESE 1PP) TO 354422N0941351W (20NM E 1PP) TO 354316N0941354W (20NM ESE 1PP) TO 354107N0935720W (11.1NM NW 7M5) TO 354433N0934627W (13.3NM NE 7M5) TO 354614N0934235W (16.3NM NE 7M5) TO 354554N0933422W (18.8NM NE 7M5) TO 355354N0933001W (16.7NM SE H34) TO 355442N0933218W (14.4NM SE H34) TO 355544N0934054W (10.3NM SE H34) TO 355629N0934400W (8.4NM SSE H34) TO 360015N0934447W (4.3NM SSE H34) TO 360236N0934608W (2.3NM SW H34) TO 360653N0934613W (1NM NW H34) TO 361119N0934757W (6NM NNW H34) TO 361353N0935048W (9NM NW H34) TO 361528N0935607W (9.6NM NE ASG) TO 361518N0940113W (6NM NE ASG) TO POINT OF ORIGIN SFC-200FT AGL"
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [
+                    [
+                      [-94.207808, 36.368889],
+                      [-94.207888, 36.367576],
+                      [-94.208127, 36.366275],
+                      [-94.208524, 36.365],
+                      [-94.209074, 36.363762],
+                      [-94.209772, 36.362574],
+                      [-94.210611, 36.361446],
+                      [-94.211584, 36.36039],
+                      [-94.21268, 36.359416],
+                      [-94.21389, 36.358533],
+                      [-94.215202, 36.35775],
+                      [-94.216602, 36.357074],
+                      [-94.218078, 36.356511],
+                      [-94.219615, 36.356068],
+                      [-94.221199, 36.355749],
+                      [-94.222814, 36.355556],
+                      [-94.224444, 36.355492],
+                      [-94.226075, 36.355556],
+                      [-94.22769, 36.355749],
+                      [-94.229274, 36.356068],
+                      [-94.230811, 36.356511],
+                      [-94.232287, 36.357074],
+                      [-94.233687, 36.35775],
+                      [-94.234999, 36.358533],
+                      [-94.236208, 36.359416],
+                      [-94.237305, 36.36039],
+                      [-94.238277, 36.361446],
+                      [-94.239117, 36.362574],
+                      [-94.239815, 36.363762],
+                      [-94.240365, 36.365],
+                      [-94.240762, 36.366275],
+                      [-94.241001, 36.367576],
+                      [-94.241081, 36.368889],
+                      [-94.241001, 36.370202],
+                      [-94.240762, 36.371502],
+                      [-94.240365, 36.372778],
+                      [-94.239815, 36.374015],
+                      [-94.239117, 36.375204],
+                      [-94.238277, 36.376331],
+                      [-94.237305, 36.377387],
+                      [-94.236208, 36.378361],
+                      [-94.234999, 36.379244],
+                      [-94.233687, 36.380027],
+                      [-94.232287, 36.380702],
+                      [-94.230811, 36.381264],
+                      [-94.229274, 36.381707],
+                      [-94.22769, 36.382027],
+                      [-94.226075, 36.382219],
+                      [-94.224444, 36.382284],
+                      [-94.222814, 36.382219],
+                      [-94.221199, 36.382027],
+                      [-94.219615, 36.381707],
+                      [-94.218078, 36.381264],
+                      [-94.216602, 36.380702],
+                      [-94.215202, 36.380027],
+                      [-94.21389, 36.379244],
+                      [-94.21268, 36.378361],
+                      [-94.211584, 36.377387],
+                      [-94.210611, 36.376331],
+                      [-94.209772, 36.375204],
+                      [-94.209074, 36.374015],
+                      [-94.208524, 36.372778],
+                      [-94.208127, 36.371502],
+                      [-94.207888, 36.370202],
+                      [-94.207808, 36.368889]
+                    ]
+                  ],
+                  "type": "Polygon"
+                },
+                "properties": {
+                  "endDateTime": "2023-03-10T02:00:00.000Z",
+                  "startDateTime": "2022-03-11T14:00:00.000Z",
+                  "text": "AIRSPACE UAS WI AN AREA DEFINED AS 1NM RADIUS OF 362208N0941328W (.7NM SW VBT) SFC-175FT AGL"
+                },
+                "type": "Feature"
+              }
+            ],
+            "type": "FeatureCollection"
+          }
+        },
+        "properties": {
+          "found": {
+            "title": "Found",
+            "type": "object"
+          }
+        },
+        "required": ["found"],
+        "title": "UOAsDistanceResponse",
+        "type": "object"
+      },
+      "UOAsPolyResponse": {
+        "example": {
+          "found": {
+            "features": [
+              {
+                "geometry": {
+                  "coordinates": [
+                    [
+                      [-84.09488, 39.385147],
+                      [-84.094337, 39.383957],
+                      [-84.093947, 39.382732],
+                      [-84.093714, 39.381483],
+                      [-84.093641, 39.380222],
+                      [-84.093729, 39.378962],
+                      [-84.093975, 39.377714],
+                      [-84.094379, 39.376491],
+                      [-84.094936, 39.375305],
+                      [-84.09564, 39.374166],
+                      [-84.096485, 39.373087],
+                      [-84.097464, 39.372076],
+                      [-84.098565, 39.371145],
+                      [-84.09978, 39.370301],
+                      [-84.101096, 39.369554],
+                      [-84.1025, 39.36891],
+                      [-84.103979, 39.368375],
+                      [-84.105518, 39.367955],
+                      [-84.107104, 39.367654],
+                      [-84.10872, 39.367474],
+                      [-84.110351, 39.367417],
+                      [-84.111981, 39.367485],
+                      [-84.113595, 39.367676],
+                      [-84.115177, 39.367988],
+                      [-84.116712, 39.368418],
+                      [-84.118184, 39.368963],
+                      [-84.119581, 39.369616],
+                      [-84.120888, 39.370373],
+                      [-84.122093, 39.371224],
+                      [-84.123184, 39.372163],
+                      [-84.124151, 39.37318],
+                      [-84.124984, 39.374265],
+                      [-84.125676, 39.375409],
+                      [-84.25012, 39.610147],
+                      [-84.250663, 39.611333],
+                      [-84.251053, 39.612555],
+                      [-84.251286, 39.613799],
+                      [-84.251359, 39.615056],
+                      [-84.251271, 39.616312],
+                      [-84.251025, 39.617555],
+                      [-84.250621, 39.618774],
+                      [-84.250064, 39.619956],
+                      [-84.24936, 39.62109],
+                      [-84.248515, 39.622166],
+                      [-84.247536, 39.623173],
+                      [-84.246435, 39.624101],
+                      [-84.24522, 39.624942],
+                      [-84.243904, 39.625686],
+                      [-84.2425, 39.626328],
+                      [-84.241021, 39.626861],
+                      [-84.239482, 39.627279],
+                      [-84.237896, 39.627579],
+                      [-84.23628, 39.627759],
+                      [-84.234649, 39.627815],
+                      [-84.233019, 39.627748],
+                      [-84.231405, 39.627558],
+                      [-84.229823, 39.627247],
+                      [-84.228288, 39.626818],
+                      [-84.226816, 39.626275],
+                      [-84.225419, 39.625624],
+                      [-84.224112, 39.624871],
+                      [-84.222907, 39.624022],
+                      [-84.221816, 39.623087],
+                      [-84.220849, 39.622073],
+                      [-84.220016, 39.620992],
+                      [-84.219324, 39.619853],
+                      [-84.09488, 39.385147]
+                    ]
+                  ],
+                  "type": "Polygon"
+                },
+                "properties": {
+                  "endDateTime": "2022-09-29T21:00:00.000Z",
+                  "startDateTime": "2022-06-29T12:00:00.000Z",
+                  "text": "AIRSPACE UAS WI AN AREA DEFINED AS 1NM EITHER SIDE OF A LINE FM 393654N0841405W ( .7NM NW MGY) TO 392249N0840637W (8.3NM E 40I) SFC-375FT DLY 1200-2100"
+                },
+                "type": "Feature"
+              }
+            ],
+            "type": "FeatureCollection"
+          }
+        },
+        "properties": {
+          "found": {
+            "title": "Found",
+            "type": "object"
+          }
+        },
+        "required": ["found"],
+        "title": "UOAsPolyResponse",
+        "type": "object"
+      },
+      "UOAsRouteResponse": {
+        "example": {
+          "found": {
+            "features": [
+              {
+                "geometry": {
+                  "coordinates": [
+                    [
+                      [-89.404767, 38.705917],
+                      [-89.405408, 38.695736],
+                      [-89.407324, 38.685651],
+                      [-89.410498, 38.675761],
+                      [-89.414898, 38.666159],
+                      [-89.420482, 38.65694],
+                      [-89.427197, 38.648191],
+                      [-89.434978, 38.639997],
+                      [-89.443749, 38.632437],
+                      [-89.453427, 38.625585],
+                      [-89.463918, 38.619506],
+                      [-89.475121, 38.61426],
+                      [-89.486928, 38.609896],
+                      [-89.499226, 38.606458],
+                      [-89.511896, 38.603977],
+                      [-89.524816, 38.60248],
+                      [-89.537861, 38.601979],
+                      [-89.550907, 38.60248],
+                      [-89.563827, 38.603977],
+                      [-89.576496, 38.606458],
+                      [-89.588794, 38.609896],
+                      [-89.600601, 38.61426],
+                      [-89.611804, 38.619506],
+                      [-89.622295, 38.625585],
+                      [-89.631973, 38.632437],
+                      [-89.640744, 38.639997],
+                      [-89.648525, 38.648191],
+                      [-89.65524, 38.65694],
+                      [-89.660824, 38.666159],
+                      [-89.665225, 38.675761],
+                      [-89.668398, 38.685651],
+                      [-89.670315, 38.695736],
+                      [-89.670956, 38.705917],
+                      [-89.670315, 38.716096],
+                      [-89.668398, 38.726176],
+                      [-89.665225, 38.73606],
+                      [-89.660824, 38.745652],
+                      [-89.65524, 38.75486],
+                      [-89.648525, 38.763596],
+                      [-89.640744, 38.771776],
+                      [-89.631973, 38.779321],
+                      [-89.622295, 38.786158],
+                      [-89.611804, 38.792223],
+                      [-89.600601, 38.797456],
+                      [-89.588794, 38.801809],
+                      [-89.576496, 38.805238],
+                      [-89.563827, 38.807711],
+                      [-89.550907, 38.809204],
+                      [-89.537861, 38.809704],
+                      [-89.524816, 38.809204],
+                      [-89.511896, 38.807711],
+                      [-89.499226, 38.805238],
+                      [-89.486928, 38.801809],
+                      [-89.475121, 38.797456],
+                      [-89.463918, 38.792223],
+                      [-89.453427, 38.786158],
+                      [-89.443749, 38.779321],
+                      [-89.434978, 38.771776],
+                      [-89.427197, 38.763596],
+                      [-89.420482, 38.75486],
+                      [-89.414898, 38.745652],
+                      [-89.410498, 38.73606],
+                      [-89.407324, 38.726176],
+                      [-89.405408, 38.716096],
+                      [-89.404767, 38.705917]
+                    ]
+                  ],
+                  "type": "Polygon"
+                },
+                "properties": {
+                  "endDateTime": "2022-10-01T02:00:00.000Z",
+                  "startDateTime": "2022-09-02T11:30:00.000Z",
+                  "text": "AIRSPACE UAS WI AN AREA DEFINED AS 8NM RADIUS OF 384221.30N0893216.30W (6.5NM SE H07) SFC-100FT AGL DLY 1130-0200"
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [
+                    [
+                      [-89.059767, 38.610611],
+                      [-89.060408, 38.600417],
+                      [-89.062324, 38.590319],
+                      [-89.065498, 38.580415],
+                      [-89.069898, 38.570801],
+                      [-89.075482, 38.561569],
+                      [-89.082197, 38.552808],
+                      [-89.089978, 38.544603],
+                      [-89.098749, 38.537034],
+                      [-89.108427, 38.530173],
+                      [-89.118918, 38.524086],
+                      [-89.130121, 38.518832],
+                      [-89.141928, 38.514463],
+                      [-89.154226, 38.51102],
+                      [-89.166896, 38.508536],
+                      [-89.179816, 38.507037],
+                      [-89.192861, 38.506535],
+                      [-89.205907, 38.507037],
+                      [-89.218827, 38.508536],
+                      [-89.231496, 38.51102],
+                      [-89.243794, 38.514463],
+                      [-89.255601, 38.518832],
+                      [-89.266804, 38.524086],
+                      [-89.277295, 38.530173],
+                      [-89.286973, 38.537034],
+                      [-89.295744, 38.544603],
+                      [-89.303525, 38.552808],
+                      [-89.31024, 38.561569],
+                      [-89.315824, 38.570801],
+                      [-89.320225, 38.580415],
+                      [-89.323398, 38.590319],
+                      [-89.325315, 38.600417],
+                      [-89.325956, 38.610611],
+                      [-89.325315, 38.620804],
+                      [-89.323398, 38.630898],
+                      [-89.320225, 38.640795],
+                      [-89.315824, 38.650399],
+                      [-89.31024, 38.65962],
+                      [-89.303525, 38.668367],
+                      [-89.295744, 38.676558],
+                      [-89.286973, 38.684113],
+                      [-89.277295, 38.69096],
+                      [-89.266804, 38.697032],
+                      [-89.255601, 38.702273],
+                      [-89.243794, 38.706631],
+                      [-89.231496, 38.710064],
+                      [-89.218827, 38.712541],
+                      [-89.205907, 38.714036],
+                      [-89.192861, 38.714536],
+                      [-89.179816, 38.714036],
+                      [-89.166896, 38.712541],
+                      [-89.154226, 38.710064],
+                      [-89.141928, 38.706631],
+                      [-89.130121, 38.702273],
+                      [-89.118918, 38.697032],
+                      [-89.108427, 38.69096],
+                      [-89.098749, 38.684113],
+                      [-89.089978, 38.676558],
+                      [-89.082197, 38.668367],
+                      [-89.075482, 38.65962],
+                      [-89.069898, 38.650399],
+                      [-89.065498, 38.640795],
+                      [-89.062324, 38.630898],
+                      [-89.060408, 38.620804],
+                      [-89.059767, 38.610611]
+                    ]
+                  ],
+                  "type": "Polygon"
+                },
+                "properties": {
+                  "endDateTime": "2022-09-29T02:00:00.000Z",
+                  "startDateTime": "2022-09-14T11:30:00.000Z",
+                  "text": "AIRSPACE UAS WI AN AREA DEFINED AS 8NM RADIUS OF 383638.20N0891134.30W (7.5NM NW ENL) SFC-100FT AGL DLY 1130-0200"
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [
+                    [
+                      [-89.141156, 38.441722],
+                      [-89.141796, 38.431504],
+                      [-89.143713, 38.421382],
+                      [-89.146887, 38.411455],
+                      [-89.151287, 38.401818],
+                      [-89.156871, 38.392565],
+                      [-89.163586, 38.383784],
+                      [-89.171367, 38.37556],
+                      [-89.180138, 38.367972],
+                      [-89.189816, 38.361095],
+                      [-89.200307, 38.354994],
+                      [-89.21151, 38.349728],
+                      [-89.223317, 38.345348],
+                      [-89.235615, 38.341897],
+                      [-89.248285, 38.339408],
+                      [-89.261204, 38.337905],
+                      [-89.27425, 38.337402],
+                      [-89.287296, 38.337905],
+                      [-89.300215, 38.339408],
+                      [-89.312885, 38.341897],
+                      [-89.325183, 38.345348],
+                      [-89.33699, 38.349728],
+                      [-89.348193, 38.354994],
+                      [-89.358684, 38.361095],
+                      [-89.368362, 38.367972],
+                      [-89.377133, 38.37556],
+                      [-89.384914, 38.383784],
+                      [-89.391629, 38.392565],
+                      [-89.397213, 38.401818],
+                      [-89.401613, 38.411455],
+                      [-89.404787, 38.421382],
+                      [-89.406704, 38.431504],
+                      [-89.407344, 38.441722],
+                      [-89.406704, 38.451939],
+                      [-89.404787, 38.462057],
+                      [-89.401613, 38.471977],
+                      [-89.397213, 38.481604],
+                      [-89.391629, 38.490846],
+                      [-89.384914, 38.499614],
+                      [-89.377133, 38.507824],
+                      [-89.368362, 38.515397],
+                      [-89.358684, 38.52226],
+                      [-89.348193, 38.528347],
+                      [-89.33699, 38.5336],
+                      [-89.325183, 38.537968],
+                      [-89.312885, 38.541409],
+                      [-89.300215, 38.543892],
+                      [-89.287296, 38.545391],
+                      [-89.27425, 38.545892],
+                      [-89.261204, 38.545391],
+                      [-89.248285, 38.543892],
+                      [-89.235615, 38.541409],
+                      [-89.223317, 38.537968],
+                      [-89.21151, 38.5336],
+                      [-89.200307, 38.528347],
+                      [-89.189816, 38.52226],
+                      [-89.180138, 38.515397],
+                      [-89.171367, 38.507824],
+                      [-89.163586, 38.499614],
+                      [-89.156871, 38.490846],
+                      [-89.151287, 38.481604],
+                      [-89.146887, 38.471977],
+                      [-89.143713, 38.462057],
+                      [-89.141796, 38.451939],
+                      [-89.141156, 38.441722]
+                    ]
+                  ],
+                  "type": "Polygon"
+                },
+                "properties": {
+                  "endDateTime": "2022-09-30T02:00:00.000Z",
+                  "startDateTime": "2022-09-15T11:30:00.000Z",
+                  "text": "AIRSPACE UAS WI AN AREA DEFINED AS 8NM RADIUS OF 382630.20N0891627.30W (9.7NM WSW ENL) SFC-100FT AGL DLY 1130-0200"
+                },
+                "type": "Feature"
+              }
+            ],
+            "type": "FeatureCollection"
+          }
+        },
+        "properties": {
+          "found": {
+            "title": "Found",
+            "type": "object"
+          }
+        },
+        "required": ["found"],
+        "title": "UOAsRouteResponse",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": ["loc", "msg", "type"],
+        "title": "ValidationError",
+        "type": "object"
+      },
+      "VenueDistanceResponse": {
+        "example": {
+          "found": {
+            "features": [
+              {
+                "geometry": {
+                  "coordinates": [
+                    [
+                      [-97.033943, 32.747691],
+                      [-97.034183, 32.743576],
+                      [-97.034902, 32.739501],
+                      [-97.036092, 32.735504],
+                      [-97.037742, 32.731625],
+                      [-97.039836, 32.7279],
+                      [-97.042354, 32.724366],
+                      [-97.045272, 32.721056],
+                      [-97.048561, 32.718003],
+                      [-97.052191, 32.715235],
+                      [-97.056125, 32.712781],
+                      [-97.060326, 32.710662],
+                      [-97.064754, 32.7089],
+                      [-97.069365, 32.707511],
+                      [-97.074116, 32.70651],
+                      [-97.078961, 32.705905],
+                      [-97.083853, 32.705703],
+                      [-97.088745, 32.705905],
+                      [-97.09359, 32.70651],
+                      [-97.098342, 32.707511],
+                      [-97.102953, 32.7089],
+                      [-97.107381, 32.710662],
+                      [-97.111582, 32.712781],
+                      [-97.115516, 32.715235],
+                      [-97.119145, 32.718003],
+                      [-97.122435, 32.721056],
+                      [-97.125352, 32.724366],
+                      [-97.12787, 32.7279],
+                      [-97.129965, 32.731625],
+                      [-97.131615, 32.735504],
+                      [-97.132805, 32.739501],
+                      [-97.133523, 32.743576],
+                      [-97.133764, 32.747691],
+                      [-97.133523, 32.751805],
+                      [-97.132805, 32.75588],
+                      [-97.131615, 32.759875],
+                      [-97.129965, 32.763753],
+                      [-97.12787, 32.767477],
+                      [-97.125352, 32.771009],
+                      [-97.122435, 32.774317],
+                      [-97.119145, 32.777368],
+                      [-97.115516, 32.780134],
+                      [-97.111582, 32.782587],
+                      [-97.107381, 32.784704],
+                      [-97.102953, 32.786464],
+                      [-97.098342, 32.787852],
+                      [-97.09359, 32.788852],
+                      [-97.088745, 32.789456],
+                      [-97.083853, 32.789658],
+                      [-97.078961, 32.789456],
+                      [-97.074116, 32.788852],
+                      [-97.069365, 32.787852],
+                      [-97.064754, 32.786464],
+                      [-97.060326, 32.784704],
+                      [-97.056125, 32.782587],
+                      [-97.052191, 32.780134],
+                      [-97.048561, 32.777368],
+                      [-97.045272, 32.774317],
+                      [-97.042354, 32.771009],
+                      [-97.039836, 32.767477],
+                      [-97.037742, 32.763753],
+                      [-97.036092, 32.759875],
+                      [-97.034902, 32.75588],
+                      [-97.034183, 32.751805],
+                      [-97.033943, 32.747691]
+                    ]
+                  ],
+                  "type": "Polygon"
+                },
+                "properties": {
+                  "name": "Globe Life Field",
+                  "venue_type": "MLB Stadium"
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [
+                    [
+                      [-97.042464, 32.746931],
+                      [-97.042704, 32.742816],
+                      [-97.043423, 32.738741],
+                      [-97.044613, 32.734744],
+                      [-97.046263, 32.730865],
+                      [-97.048357, 32.72714],
+                      [-97.050875, 32.723606],
+                      [-97.053793, 32.720296],
+                      [-97.057082, 32.717243],
+                      [-97.060711, 32.714475],
+                      [-97.064645, 32.71202],
+                      [-97.068846, 32.709902],
+                      [-97.073274, 32.708139],
+                      [-97.077886, 32.706751],
+                      [-97.082637, 32.70575],
+                      [-97.087482, 32.705145],
+                      [-97.092374, 32.704943],
+                      [-97.097266, 32.705145],
+                      [-97.102111, 32.70575],
+                      [-97.106862, 32.706751],
+                      [-97.111474, 32.708139],
+                      [-97.115902, 32.709902],
+                      [-97.120103, 32.71202],
+                      [-97.124037, 32.714475],
+                      [-97.127666, 32.717243],
+                      [-97.130955, 32.720296],
+                      [-97.133873, 32.723606],
+                      [-97.136391, 32.72714],
+                      [-97.138485, 32.730865],
+                      [-97.140135, 32.734744],
+                      [-97.141325, 32.738741],
+                      [-97.142044, 32.742816],
+                      [-97.142284, 32.746931],
+                      [-97.142044, 32.751045],
+                      [-97.141325, 32.75512],
+                      [-97.140135, 32.759115],
+                      [-97.138485, 32.762993],
+                      [-97.136391, 32.766717],
+                      [-97.133873, 32.770249],
+                      [-97.130955, 32.773557],
+                      [-97.127666, 32.776609],
+                      [-97.124037, 32.779374],
+                      [-97.120103, 32.781827],
+                      [-97.115902, 32.783944],
+                      [-97.111474, 32.785705],
+                      [-97.106862, 32.787092],
+                      [-97.102111, 32.788092],
+                      [-97.097266, 32.788697],
+                      [-97.092374, 32.788899],
+                      [-97.087482, 32.788697],
+                      [-97.082637, 32.788092],
+                      [-97.077886, 32.787092],
+                      [-97.073274, 32.785705],
+                      [-97.068846, 32.783944],
+                      [-97.064645, 32.781827],
+                      [-97.060711, 32.779374],
+                      [-97.057082, 32.776609],
+                      [-97.053793, 32.773557],
+                      [-97.050875, 32.770249],
+                      [-97.048357, 32.766717],
+                      [-97.046263, 32.762993],
+                      [-97.044613, 32.759115],
+                      [-97.043423, 32.75512],
+                      [-97.042704, 32.751045],
+                      [-97.042464, 32.746931]
+                    ]
+                  ],
+                  "type": "Polygon"
+                },
+                "properties": {
+                  "name": "Cowboys Stadium",
+                  "venue_type": "NFL Stadium"
+                },
+                "type": "Feature"
+              }
+            ],
+            "type": "FeatureCollection"
+          }
+        },
+        "properties": {
+          "found": {
+            "title": "Found",
+            "type": "object"
+          }
+        },
+        "required": ["found"],
+        "title": "VenueDistanceResponse",
+        "type": "object"
+      },
+      "VenuePolyResponse": {
+        "example": {
+          "found": {
+            "features": [
+              {
+                "geometry": {
+                  "coordinates": [
+                    [
+                      [-68.189769, 44.31524],
+                      [-68.189809, 44.315239],
+                      [-68.189923, 44.315236],
+                      [-68.190457, 44.315117],
+                      [-68.190719, 44.314945],
+                      [-68.19101, 44.314879],
+                      [-68.191342, 44.314909],
+                      [-68.192141, 44.314717],
+                      [-68.192706, 44.314694],
+                      [-68.193691, 44.314939],
+                      [-68.194116, 44.315207],
+                      [-68.194309, 44.315513],
+                      [-68.194312, 44.315887],
+                      [-68.194494, 44.316183],
+                      [-68.194733, 44.316406],
+                      [-68.194973, 44.316629],
+                      [-68.195626, 44.317134],
+                      [-68.195645, 44.317157],
+                      [-68.196011, 44.317604],
+                      [-68.196034, 44.317649],
+                      [-68.196297, 44.318174],
+                      [-68.196857, 44.319151],
+                      [-68.197486, 44.319878],
+                      [-68.198065, 44.320544],
+                      [-68.197795, 44.320665],
+                      [-68.197108, 44.320973],
+                      [-68.197301, 44.321277],
+                      [-68.196269, 44.321714],
+                      [-68.197225, 44.323107],
+                      [-68.198569, 44.325587],
+                      [-68.198775, 44.326751],
+                      [-68.198909, 44.327509],
+                      [-68.199217, 44.328376],
+                      [-68.200926, 44.328273],
+                      [-68.201378, 44.330331],
+                      [-68.20059, 44.330417],
+                      [-68.200374, 44.330503],
+                      [-68.200141, 44.330595],
+                      [-68.200124, 44.331468],
+                      [-68.200124, 44.331468],
+                      [-68.200109, 44.331799],
+                      [-68.200109, 44.331799],
+                      [-68.200118, 44.332522],
+                      [-68.200302, 44.333796],
+                      [-68.200671, 44.333829],
+                      [-68.201793, 44.333927],
+                      [-68.202088, 44.334472],
+                      [-68.201411, 44.335379],
+                      [-68.201837, 44.335434],
+                      [-68.202505, 44.337234],
+                      [-68.20288, 44.337576],
+                      [-68.203255, 44.337757],
+                      [-68.203206, 44.337415],
+                      [-68.2067, 44.336237],
+                      [-68.206449, 44.336001],
+                      [-68.206488, 44.335522],
+                      [-68.206733, 44.335192],
+                      [-68.206482, 44.334233],
+                      [-68.206074, 44.333405],
+                      [-68.206148, 44.333097],
+                      [-68.206617, 44.332312],
+                      [-68.206834, 44.331949],
+                      [-68.207347, 44.331393],
+                      [-68.209276, 44.331555],
+                      [-68.209547, 44.329696],
+                      [-68.209475, 44.329245],
+                      [-68.209402, 44.328794],
+                      [-68.208924, 44.325814],
+                      [-68.2087, 44.324103],
+                      [-68.208581, 44.323195],
+                      [-68.206961, 44.323515],
+                      [-68.207057, 44.322528],
+                      [-68.214114, 44.321193],
+                      [-68.210884, 44.315727],
+                      [-68.211465, 44.314866],
+                      [-68.212043, 44.314712],
+                      [-68.211946, 44.314408],
+                      [-68.213411, 44.314012],
+                      [-68.212734, 44.31296],
+                      [-68.212152, 44.312808],
+                      [-68.211543, 44.313091],
+                      [-68.211194, 44.313419],
+                      [-68.210934, 44.313445],
+                      [-68.210783, 44.313818],
+                      [-68.209, 44.313369],
+                      [-68.209431, 44.313842],
+                      [-68.209712, 44.314812],
+                      [-68.208558, 44.314933],
+                      [-68.206552, 44.314306],
+                      [-68.205871, 44.31417],
+                      [-68.205968, 44.314687],
+                      [-68.203267, 44.315668],
+                      [-68.203649, 44.31615],
+                      [-68.203239, 44.316362],
+                      [-68.204632, 44.318129],
+                      [-68.204433, 44.318213],
+                      [-68.204234, 44.318297],
+                      [-68.204751, 44.319272],
+                      [-68.204005, 44.319635],
+                      [-68.204683, 44.320455],
+                      [-68.204264, 44.320912],
+                      [-68.204212, 44.320968],
+                      [-68.203825, 44.322321],
+                      [-68.203376, 44.323574],
+                      [-68.203325, 44.323633],
+                      [-68.203274, 44.323692],
+                      [-68.203586, 44.324149],
+                      [-68.203999, 44.32509],
+                      [-68.20379, 44.325728],
+                      [-68.204099, 44.326304],
+                      [-68.204145, 44.326578],
+                      [-68.203885, 44.326649],
+                      [-68.203321, 44.325429],
+                      [-68.202167, 44.325647],
+                      [-68.201926, 44.324408],
+                      [-68.202369, 44.324344],
+                      [-68.201762, 44.324285],
+                      [-68.201421, 44.324347],
+                      [-68.20116, 44.324447],
+                      [-68.20007, 44.324506],
+                      [-68.200133, 44.32406],
+                      [-68.200377, 44.322316],
+                      [-68.198615, 44.320815],
+                      [-68.198273, 44.320451],
+                      [-68.197569, 44.319708],
+                      [-68.197351, 44.319479],
+                      [-68.196857, 44.318727],
+                      [-68.196686, 44.318467],
+                      [-68.196301, 44.317643],
+                      [-68.196244, 44.317562],
+                      [-68.196022, 44.317248],
+                      [-68.195834, 44.317087],
+                      [-68.195565, 44.316856],
+                      [-68.195381, 44.316699],
+                      [-68.194865, 44.316308],
+                      [-68.194834, 44.316284],
+                      [-68.194674, 44.316082],
+                      [-68.194515, 44.315879],
+                      [-68.194471, 44.315363],
+                      [-68.194272, 44.315121],
+                      [-68.194175, 44.315055],
+                      [-68.193764, 44.314777],
+                      [-68.193049, 44.314571],
+                      [-68.192457, 44.314527],
+                      [-68.191814, 44.314608],
+                      [-68.19132, 44.314738],
+                      [-68.190955, 44.314709],
+                      [-68.190653, 44.314789],
+                      [-68.19049, 44.314886],
+                      [-68.189935, 44.315054],
+                      [-68.189778, 44.315053],
+                      [-68.189808, 44.314486],
+                      [-68.190122, 44.313833],
+                      [-68.18955, 44.312823],
+                      [-68.188883, 44.312156],
+                      [-68.188586, 44.311665],
+                      [-68.188331, 44.311242],
+                      [-68.187936, 44.309938],
+                      [-68.188164, 44.309515],
+                      [-68.188083, 44.309345],
+                      [-68.187753, 44.309314],
+                      [-68.187735, 44.308856],
+                      [-68.187937, 44.308083],
+                      [-68.189032, 44.306803],
+                      [-68.189652, 44.306712],
+                      [-68.190108, 44.306789],
+                      [-68.190209, 44.306777],
+                      [-68.191091, 44.306674],
+                      [-68.191653, 44.306575],
+                      [-68.192099, 44.306349],
+                      [-68.193114, 44.306897],
+                      [-68.192767, 44.308315],
+                      [-68.193278, 44.309285],
+                      [-68.193472, 44.310083],
+                      [-68.194103, 44.310319],
+                      [-68.194632, 44.310667],
+                      [-68.195491, 44.311827],
+                      [-68.195744, 44.312314],
+                      [-68.196046, 44.312898],
+                      [-68.196158, 44.313138],
+                      [-68.196432, 44.313722],
+                      [-68.1968, 44.31491],
+                      [-68.197271, 44.315244],
+                      [-68.197319, 44.315278],
+                      [-68.197453, 44.315373],
+                      [-68.197726, 44.316329],
+                      [-68.197748, 44.316406],
+                      [-68.198109, 44.316755],
+                      [-68.198227, 44.316868],
+                      [-68.198442, 44.316992],
+                      [-68.199288, 44.316721],
+                      [-68.199968, 44.316533],
+                      [-68.19944, 44.316901],
+                      [-68.198814, 44.317108],
+                      [-68.198256, 44.317159],
+                      [-68.197595, 44.317072],
+                      [-68.197525, 44.317017],
+                      [-68.197047, 44.316644],
+                      [-68.197019, 44.316604],
+                      [-68.196939, 44.316491],
+                      [-68.196371, 44.315686],
+                      [-68.196346, 44.31565],
+                      [-68.196138, 44.315325],
+                      [-68.195966, 44.315057],
+                      [-68.195834, 44.314852],
+                      [-68.195415, 44.313917],
+                      [-68.195144, 44.313281],
+                      [-68.195048, 44.313055],
+                      [-68.194824, 44.312414],
+                      [-68.19456, 44.312462],
+                      [-68.194918, 44.313298],
+                      [-68.195647, 44.315],
+                      [-68.195839, 44.315282],
+                      [-68.196165, 44.315759],
+                      [-68.196631, 44.316444],
+                      [-68.196814, 44.316713],
+                      [-68.197207, 44.31704],
+                      [-68.197327, 44.317089],
+                      [-68.197793, 44.317282],
+                      [-68.198307, 44.317337],
+                      [-68.198969, 44.317237],
+                      [-68.199796, 44.316866],
+                      [-68.200066, 44.316711],
+                      [-68.200165, 44.31689],
+                      [-68.198606, 44.317491],
+                      [-68.198445, 44.318039],
+                      [-68.198403, 44.318179],
+                      [-68.198483, 44.318761],
+                      [-68.198846, 44.319085],
+                      [-68.199209, 44.319408],
+                      [-68.200037, 44.320224],
+                      [-68.200135, 44.320302],
+                      [-68.201193, 44.322174],
+                      [-68.201385, 44.322463],
+                      [-68.201359, 44.322711],
+                      [-68.201476, 44.322898],
+                      [-68.201702, 44.323013],
+                      [-68.201763, 44.32299],
+                      [-68.201725, 44.322725],
+                      [-68.201899, 44.322635],
+                      [-68.20212, 44.322663],
+                      [-68.202202, 44.322674],
+                      [-68.202302, 44.322646],
+                      [-68.202281, 44.322535],
+                      [-68.20226, 44.322425],
+                      [-68.202425, 44.322275],
+                      [-68.202379, 44.321979],
+                      [-68.202377, 44.32181],
+                      [-68.202985, 44.321719],
+                      [-68.203062, 44.321639],
+                      [-68.202885, 44.321138],
+                      [-68.202823, 44.321058],
+                      [-68.202605, 44.320774],
+                      [-68.20196, 44.319978],
+                      [-68.201436, 44.319393],
+                      [-68.201295, 44.31903],
+                      [-68.20108, 44.318474],
+                      [-68.200808, 44.317279],
+                      [-68.200716, 44.316928],
+                      [-68.200801, 44.316385],
+                      [-68.200565, 44.316173],
+                      [-68.20037, 44.316071],
+                      [-68.200258, 44.314966],
+                      [-68.200076, 44.314291],
+                      [-68.199961, 44.314103],
+                      [-68.199809, 44.313854],
+                      [-68.199658, 44.313604],
+                      [-68.199582, 44.31348],
+                      [-68.199299, 44.313016],
+                      [-68.19929, 44.312952],
+                      [-68.199161, 44.311994],
+                      [-68.199259, 44.311194],
+                      [-68.199721, 44.310032],
+                      [-68.199555, 44.30869],
+                      [-68.199764, 44.307764],
+                      [-68.200193, 44.306805],
+                      [-68.200826, 44.305947],
+                      [-68.2016, 44.305239],
+                      [-68.201872, 44.304334],
+                      [-68.202142, 44.30385],
+                      [-68.202162, 44.302947],
+                      [-68.202197, 44.30219],
+                      [-68.202451, 44.301762],
+                      [-68.203269, 44.301539],
+                      [-68.205223, 44.300494],
+                      [-68.205261, 44.299789],
+                      [-68.20571, 44.29979],
+                      [-68.206162, 44.299682],
+                      [-68.206682, 44.299432],
+                      [-68.206989, 44.29892],
+                      [-68.207132, 44.298233],
+                      [-68.207583, 44.297932],
+                      [-68.208355, 44.297753],
+                      [-68.208999, 44.297733],
+                      [-68.209326, 44.29764],
+                      [-68.210058, 44.297349],
+                      [-68.210768, 44.297512],
+                      [-68.211368, 44.29815],
+                      [-68.211961, 44.297871],
+                      [-68.211692, 44.297251],
+                      [-68.212165, 44.296613],
+                      [-68.213073, 44.296347],
+                      [-68.214277, 44.29627],
+                      [-68.214995, 44.296555],
+                      [-68.215664, 44.297356],
+                      [-68.216287, 44.298006],
+                      [-68.216587, 44.298356],
+                      [-68.216793, 44.298856],
+                      [-68.216925, 44.299002],
+                      [-68.217057, 44.299147],
+                      [-68.217657, 44.299218],
+                      [-68.218082, 44.299206],
+                      [-68.218264, 44.300899],
+                      [-68.218308, 44.301595],
+                      [-68.219517, 44.302595],
+                      [-68.219899, 44.304122],
+                      [-68.220946, 44.30459],
+                      [-68.225108, 44.304406],
+                      [-68.226041, 44.304359],
+                      [-68.225675, 44.303538],
+                      [-68.22569, 44.303016],
+                      [-68.225906, 44.302556],
+                      [-68.226551, 44.302241],
+                      [-68.227849, 44.302201],
+                      [-68.228797, 44.301399],
+                      [-68.229595, 44.301298],
+                      [-68.230257, 44.301438],
+                      [-68.230668, 44.301864],
+                      [-68.23131, 44.302483],
+                      [-68.232159, 44.302731],
+                      [-68.233138, 44.303042],
+                      [-68.233524, 44.30352],
+                      [-68.233916, 44.304205],
+                      [-68.234414, 44.304418],
+                      [-68.234806, 44.304942],
+                      [-68.235144, 44.304482],
+                      [-68.235475, 44.305001],
+                      [-68.235643, 44.30532],
+                      [-68.2358, 44.30569],
+                      [-68.236036, 44.306565],
+                      [-68.236244, 44.307008],
+                      [-68.236626, 44.3079],
+                      [-68.23675, 44.308132],
+                      [-68.237805, 44.308096],
+                      [-68.238341, 44.308156],
+                      [-68.238693, 44.30829],
+                      [-68.239381, 44.308644],
+                      [-68.239643, 44.308758],
+                      [-68.240134, 44.308907],
+                      [-68.24123, 44.308946],
+                      [-68.241344, 44.309268],
+                      [-68.242722, 44.309052],
+                      [-68.242896, 44.309503],
+                      [-68.243418, 44.309442],
+                      [-68.243494, 44.309565],
+                      [-68.24442, 44.309434],
+                      [-68.244485, 44.309635],
+                      [-68.243557, 44.309756],
+                      [-68.243568, 44.309818],
+                      [-68.243592, 44.309953],
+                      [-68.243657, 44.310147],
+                      [-68.243443, 44.310179],
+                      [-68.243453, 44.310278],
+                      [-68.243562, 44.310674],
+                      [-68.243783, 44.310645],
+                      [-68.243743, 44.310258],
+                      [-68.243964, 44.310199],
+                      [-68.244073, 44.310586],
+                      [-68.244387, 44.310935],
+                      [-68.243196, 44.31114],
+                      [-68.242774, 44.311346],
+                      [-68.242951, 44.311929],
+                      [-68.243422, 44.312087],
+                      [-68.245438, 44.311797],
+                      [-68.245621, 44.311962],
+                      [-68.247189, 44.313362],
+                      [-68.248319, 44.314586],
+                      [-68.24664, 44.314806],
+                      [-68.245897, 44.314527],
+                      [-68.244981, 44.313861],
+                      [-68.244512, 44.314054],
+                      [-68.244345, 44.314464],
+                      [-68.244487, 44.315244],
+                      [-68.248211, 44.314672],
+                      [-68.248308, 44.314692],
+                      [-68.248405, 44.314675],
+                      [-68.249972, 44.316293],
+                      [-68.250761, 44.317251],
+                      [-68.251209, 44.31782],
+                      [-68.251574, 44.318286],
+                      [-68.251939, 44.318682],
+                      [-68.25279, 44.319839],
+                      [-68.252865, 44.3202],
+                      [-68.252854, 44.320465],
+                      [-68.252711, 44.320655],
+                      [-68.252454, 44.320811],
+                      [-68.252055, 44.320824],
+                      [-68.251107, 44.320727],
+                      [-68.250461, 44.320732],
+                      [-68.249909, 44.320821],
+                      [-68.249462, 44.321065],
+                      [-68.249033, 44.321543],
+                      [-68.24887, 44.322173],
+                      [-68.2489, 44.323179],
+                      [-68.249086, 44.322985],
+                      [-68.249061, 44.322184],
+                      [-68.249213, 44.321595],
+                      [-68.249605, 44.321159],
+                      [-68.249992, 44.320948],
+                      [-68.250483, 44.320869],
+                      [-68.251094, 44.320864],
+                      [-68.252046, 44.320962],
+                      [-68.252528, 44.320946],
+                      [-68.252862, 44.320743],
+                      [-68.253044, 44.320502],
+                      [-68.253056, 44.320191],
+                      [-68.252975, 44.319795],
+                      [-68.252928, 44.319719],
+                      [-68.252716, 44.319373],
+                      [-68.252044, 44.318536],
+                      [-68.250302, 44.316256],
+                      [-68.256472, 44.313118],
+                      [-68.258493, 44.313023],
+                      [-68.25891, 44.312472],
+                      [-68.257734, 44.307071],
+                      [-68.260134, 44.306783],
+                      [-68.259915, 44.305151],
+                      [-68.272875, 44.303772],
+                      [-68.274277, 44.309125],
+                      [-68.277071, 44.308626],
+                      [-68.279729, 44.310996],
+                      [-68.280892, 44.310887],
+                      [-68.281099, 44.312015],
+                      [-68.281741, 44.311858],
+                      [-68.281579, 44.311004],
+                      [-68.283866, 44.310705],
+                      [-68.283473, 44.309916],
+                      [-68.282736, 44.309423],
+                      [-68.283441, 44.308739],
+                      [-68.284525, 44.308325],
+                      [-68.284168, 44.307458],
+                      [-68.283922, 44.305683],
+                      [-68.284287, 44.304504],
+                      [-68.285168, 44.304663],
+                      [-68.285211, 44.304497],
+                      [-68.284406, 44.304354],
+                      [-68.285138, 44.30342],
+                      [-68.285249, 44.30277],
+                      [-68.284761, 44.30092],
+                      [-68.283797, 44.301009],
+                      [-68.283766, 44.300542],
+                      [-68.283952, 44.30034],
+                      [-68.283931, 44.300044],
+                      [-68.284646, 44.300003],
+                      [-68.285691, 44.300082],
+                      [-68.286157, 44.300652],
+                      [-68.286572, 44.300459],
+                      [-68.286934, 44.299929],
+                      [-68.286793, 44.299205],
+                      [-68.288269, 44.299286],
+                      [-68.28813, 44.297916],
+                      [-68.288509, 44.2978],
+                      [-68.28932, 44.297801],
+                      [-68.289479, 44.298629],
+                      [-68.292138, 44.30331],
+                      [-68.289742, 44.303742],
+                      [-68.289547, 44.303344],
+                      [-68.288456, 44.303508],
+                      [-68.288598, 44.303726],
+                      [-68.288205, 44.303892],
+                      [-68.28912, 44.307211],
+                      [-68.290083, 44.307201],
+                      [-68.291029, 44.307275],
+                      [-68.291707, 44.307469],
+                      [-68.292354, 44.307728],
+                      [-68.293256, 44.30927],
+                      [-68.293916, 44.310642],
+                      [-68.293904, 44.313124],
+                      [-68.291346, 44.314366],
+                      [-68.291663, 44.315524],
+                      [-68.288261, 44.316014],
+                      [-68.287487, 44.314018],
+                      [-68.286462, 44.314198],
+                      [-68.287154, 44.316485],
+                      [-68.287623, 44.31745],
+                      [-68.287401, 44.317836],
+                      [-68.287292, 44.318853],
+                      [-68.286845, 44.319125],
+                      [-68.286244, 44.319532],
+                      [-68.285764, 44.319811],
+                      [-68.285703, 44.320079],
+                      [-68.285701, 44.320476],
+                      [-68.277408, 44.32133],
+                      [-68.282059, 44.339428],
+                      [-68.283291, 44.339269],
+                      [-68.283911, 44.342566],
+                      [-68.297863, 44.340678],
+                      [-68.298353, 44.340619],
+                      [-68.299952, 44.344968],
+                      [-68.300173, 44.345568],
+                      [-68.300861, 44.347438],
+                      [-68.301001, 44.347661],
+                      [-68.29515, 44.348488],
+                      [-68.293757, 44.350928],
+                      [-68.293967, 44.353376],
+                      [-68.290028, 44.354622],
+                      [-68.290039, 44.354857],
+                      [-68.292863, 44.354051],
+                      [-68.292964, 44.354922],
+                      [-68.290123, 44.355305],
+                      [-68.290221, 44.356212],
+                      [-68.286274, 44.356732],
+                      [-68.28659, 44.358492],
+                      [-68.286602, 44.358581],
+                      [-68.287125, 44.361479],
+                      [-68.287556, 44.364018],
+                      [-68.28772, 44.363926],
+                      [-68.287904, 44.363844],
+                      [-68.288202, 44.363809],
+                      [-68.288345, 44.363863],
+                      [-68.288468, 44.364508],
+                      [-68.292825, 44.364157],
+                      [-68.2974, 44.363817],
+                      [-68.302069, 44.363449],
+                      [-68.306652, 44.363087],
+                      [-68.307175, 44.36352],
+                      [-68.307854, 44.363908],
+                      [-68.30784, 44.363672],
+                      [-68.308098, 44.363667],
+                      [-68.307998, 44.362932],
+                      [-68.308977, 44.362872],
+                      [-68.308906, 44.363113],
+                      [-68.308936, 44.363253],
+                      [-68.309053, 44.36345],
+                      [-68.309241, 44.363761],
+                      [-68.309601, 44.363846],
+                      [-68.309764, 44.3643],
+                      [-68.310037, 44.364301],
+                      [-68.310468, 44.364279],
+                      [-68.310883, 44.364184],
+                      [-68.311439, 44.36409],
+                      [-68.312032, 44.364002],
+                      [-68.312657, 44.364019],
+                      [-68.313385, 44.364082],
+                      [-68.314057, 44.364268],
+                      [-68.313965, 44.365994],
+                      [-68.313881, 44.367758],
+                      [-68.31387, 44.368803],
+                      [-68.314039, 44.36963],
+                      [-68.312896, 44.369903],
+                      [-68.317539, 44.371973],
+                      [-68.315667, 44.372429],
+                      [-68.316472, 44.37566],
+                      [-68.315277, 44.376604],
+                      [-68.312513, 44.378902],
+                      [-68.310752, 44.380304],
+                      [-68.309363, 44.38144],
+                      [-68.30708, 44.379962],
+                      [-68.305854, 44.379209],
+                      [-68.30563, 44.378297],
+                      [-68.305261, 44.376967],
+                      [-68.29747, 44.375213],
+                      [-68.297358, 44.375723],
+                      [-68.297065, 44.376695],
+                      [-68.29681, 44.377897],
+                      [-68.296674, 44.378716],
+                      [-68.296624, 44.379294],
+                      [-68.299875, 44.379155],
+                      [-68.29996, 44.379089],
+                      [-68.301528, 44.380144],
+                      [-68.297651, 44.383368],
+                      [-68.295847, 44.384866],
+                      [-68.295641, 44.385037],
+                      [-68.294065, 44.384031],
+                      [-68.293467, 44.383203],
+                      [-68.292451, 44.382982],
+                      [-68.29122, 44.382466],
+                      [-68.290343, 44.382442],
+                      [-68.289916, 44.38252],
+                      [-68.289588, 44.382725],
+                      [-68.289422, 44.382994],
+                      [-68.288887, 44.382855],
+                      [-68.289276, 44.382029],
+                      [-68.286768, 44.381449],
+                      [-68.285214, 44.380747],
+                      [-68.285244, 44.380708],
+                      [-68.285842, 44.380489],
+                      [-68.286392, 44.38021],
+                      [-68.286808, 44.379931],
+                      [-68.28722, 44.379478],
+                      [-68.287359, 44.379244],
+                      [-68.287608, 44.378219],
+                      [-68.287637, 44.377731],
+                      [-68.287707, 44.377425],
+                      [-68.287931, 44.377047],
+                      [-68.288278, 44.376669],
+                      [-68.288704, 44.376314],
+                      [-68.289247, 44.376015],
+                      [-68.283837, 44.374752],
+                      [-68.283359, 44.374645],
+                      [-68.281821, 44.3743],
+                      [-68.280803, 44.376538],
+                      [-68.278996, 44.376888],
+                      [-68.278843, 44.376547],
+                      [-68.277223, 44.375934],
+                      [-68.27662, 44.375865],
+                      [-68.276464, 44.375236],
+                      [-68.274016, 44.374807],
+                      [-68.273714, 44.375471],
+                      [-68.2728, 44.377569],
+                      [-68.273157, 44.377628],
+                      [-68.273505, 44.37773],
+                      [-68.273208, 44.378233],
+                      [-68.276679, 44.380752],
+                      [-68.277048, 44.389754],
+                      [-68.278154, 44.392285],
+                      [-68.276794, 44.395081],
+                      [-68.280424, 44.395924],
+                      [-68.277082, 44.403857],
+                      [-68.286563, 44.405781],
+                      [-68.286516, 44.409885],
+                      [-68.285428, 44.410143],
+                      [-68.28544, 44.412056],
+                      [-68.280015, 44.4131],
+                      [-68.274314, 44.411595],
+                      [-68.272135, 44.415441],
+                      [-68.26906, 44.414558],
+                      [-68.268013, 44.41647],
+                      [-68.266172, 44.416088],
+                      [-68.264657, 44.415578],
+                      [-68.265755, 44.413641],
+                      [-68.256946, 44.411574],
+                      [-68.252849, 44.410564],
+                      [-68.253002, 44.410364],
+                      [-68.253099, 44.410208],
+                      [-68.253164, 44.410101],
+                      [-68.253224, 44.409948],
+                      [-68.253279, 44.409785],
+                      [-68.253337, 44.409528],
+                      [-68.25334, 44.409329],
+                      [-68.253426, 44.408969],
+                      [-68.253518, 44.408675],
+                      [-68.253602, 44.408421],
+                      [-68.253652, 44.408159],
+                      [-68.253664, 44.407921],
+                      [-68.253624, 44.407663],
+                      [-68.253542, 44.407416],
+                      [-68.253427, 44.407078],
+                      [-68.253321, 44.406816],
+                      [-68.253254, 44.406639],
+                      [-68.253223, 44.406479],
+                      [-68.253202, 44.406245],
+                      [-68.253225, 44.406002],
+                      [-68.253267, 44.40585],
+                      [-68.25331, 44.405748],
+                      [-68.253387, 44.405567],
+                      [-68.253536, 44.405257],
+                      [-68.253665, 44.40508],
+                      [-68.253832, 44.40488],
+                      [-68.254045, 44.404577],
+                      [-68.254242, 44.404248],
+                      [-68.254295, 44.404004],
+                      [-68.254389, 44.403603],
+                      [-68.254424, 44.403377],
+                      [-68.25446, 44.403206],
+                      [-68.254499, 44.402998],
+                      [-68.254528, 44.402814],
+                      [-68.254603, 44.402479],
+                      [-68.254547, 44.402473],
+                      [-68.254471, 44.402809],
+                      [-68.254442, 44.402993],
+                      [-68.254403, 44.4032],
+                      [-68.254367, 44.403371],
+                      [-68.254332, 44.403597],
+                      [-68.254238, 44.403997],
+                      [-68.254186, 44.404237],
+                      [-68.253993, 44.404559],
+                      [-68.253782, 44.40486],
+                      [-68.253615, 44.40506],
+                      [-68.253483, 44.405241],
+                      [-68.253333, 44.405554],
+                      [-68.253245, 44.40576],
+                      [-68.253211, 44.40584],
+                      [-68.253168, 44.405997],
+                      [-68.253145, 44.406244],
+                      [-68.253166, 44.406483],
+                      [-68.253198, 44.406647],
+                      [-68.253266, 44.406827],
+                      [-68.253371, 44.407088],
+                      [-68.253486, 44.407426],
+                      [-68.253568, 44.40767],
+                      [-68.253606, 44.407923],
+                      [-68.253595, 44.408156],
+                      [-68.253546, 44.408414],
+                      [-68.253462, 44.408666],
+                      [-68.25337, 44.408961],
+                      [-68.253283, 44.409325],
+                      [-68.25328, 44.409524],
+                      [-68.253222, 44.409777],
+                      [-68.253168, 44.409938],
+                      [-68.253109, 44.410088],
+                      [-68.253047, 44.410191],
+                      [-68.25295, 44.410346],
+                      [-68.252794, 44.410551],
+                      [-68.251802, 44.410306],
+                      [-68.251622, 44.411155],
+                      [-68.251102, 44.412023],
+                      [-68.25087, 44.411824],
+                      [-68.250157, 44.411892],
+                      [-68.24986, 44.411592],
+                      [-68.24976, 44.411491],
+                      [-68.248773, 44.411161],
+                      [-68.247809, 44.410982],
+                      [-68.246845, 44.410802],
+                      [-68.245657, 44.410364],
+                      [-68.243986, 44.409747],
+                      [-68.244201, 44.409331],
+                      [-68.243893, 44.409217],
+                      [-68.243678, 44.409633],
+                      [-68.242784, 44.409303],
+                      [-68.242228, 44.409161],
+                      [-68.240474, 44.408716],
+                      [-68.240041, 44.408482],
+                      [-68.23934, 44.408274],
+                      [-68.238222, 44.407599],
+                      [-68.237432, 44.4071],
+                      [-68.236668, 44.40664],
+                      [-68.235762, 44.405972],
+                      [-68.235152, 44.405348],
+                      [-68.234838, 44.404813],
+                      [-68.235031, 44.40474],
+                      [-68.234718, 44.404303],
+                      [-68.234368, 44.404398],
+                      [-68.234002, 44.404025],
+                      [-68.233078, 44.402216],
+                      [-68.232743, 44.401558],
+                      [-68.232093, 44.400356],
+                      [-68.231648, 44.400097],
+                      [-68.231407, 44.399956],
+                      [-68.23091, 44.399666],
+                      [-68.230533, 44.399445],
+                      [-68.229623, 44.398918],
+                      [-68.229354, 44.398762],
+                      [-68.229602, 44.398529],
+                      [-68.228919, 44.397949],
+                      [-68.228493, 44.397422],
+                      [-68.227996, 44.397829],
+                      [-68.227626, 44.3975],
+                      [-68.226517, 44.396515],
+                      [-68.226928, 44.396288],
+                      [-68.226492, 44.3958],
+                      [-68.226941, 44.395306],
+                      [-68.227585, 44.394597],
+                      [-68.228445, 44.39365],
+                      [-68.22713, 44.393076],
+                      [-68.225435, 44.392335],
+                      [-68.225481, 44.391581],
+                      [-68.225166, 44.391113],
+                      [-68.224984, 44.390842],
+                      [-68.22609, 44.389656],
+                      [-68.226527, 44.389679],
+                      [-68.227428, 44.38995],
+                      [-68.228441, 44.390474],
+                      [-68.229843, 44.391193],
+                      [-68.230306, 44.391736],
+                      [-68.230414, 44.391863],
+                      [-68.23101, 44.392661],
+                      [-68.231358, 44.393179],
+                      [-68.231518, 44.393418],
+                      [-68.232146, 44.393911],
+                      [-68.232751, 44.394204],
+                      [-68.233202, 44.394264],
+                      [-68.233453, 44.394297],
+                      [-68.234077, 44.394041],
+                      [-68.234558, 44.393629],
+                      [-68.235552, 44.392625],
+                      [-68.236042, 44.392021],
+                      [-68.236211, 44.391626],
+                      [-68.236049, 44.391263],
+                      [-68.235868, 44.391763],
+                      [-68.235767, 44.391994],
+                      [-68.235604, 44.392332],
+                      [-68.234718, 44.393221],
+                      [-68.23418, 44.393711],
+                      [-68.233743, 44.394013],
+                      [-68.23342, 44.39411],
+                      [-68.233294, 44.394107],
+                      [-68.232675, 44.393974],
+                      [-68.232077, 44.393621],
+                      [-68.231477, 44.393033],
+                      [-68.230459, 44.391592],
+                      [-68.230033, 44.391129],
+                      [-68.229187, 44.390657],
+                      [-68.22746, 44.389818],
+                      [-68.226727, 44.389588],
+                      [-68.2263, 44.389431],
+                      [-68.2252, 44.389245],
+                      [-68.224338, 44.388643],
+                      [-68.223865, 44.387763],
+                      [-68.224925, 44.386852],
+                      [-68.225721, 44.38653],
+                      [-68.225585, 44.386314],
+                      [-68.226073, 44.384503],
+                      [-68.226017, 44.382913],
+                      [-68.225928, 44.380906],
+                      [-68.225184, 44.380766],
+                      [-68.224718, 44.380734],
+                      [-68.224959, 44.380482],
+                      [-68.225299, 44.380523],
+                      [-68.225894, 44.379884],
+                      [-68.225668, 44.379739],
+                      [-68.226162, 44.379156],
+                      [-68.225069, 44.378682],
+                      [-68.224497, 44.378434],
+                      [-68.223833, 44.379019],
+                      [-68.220588, 44.377711],
+                      [-68.220358, 44.377906],
+                      [-68.218698, 44.377552],
+                      [-68.21763, 44.37732],
+                      [-68.217161, 44.377443],
+                      [-68.216581, 44.37719],
+                      [-68.216145, 44.376955],
+                      [-68.215674, 44.376695],
+                      [-68.215215, 44.376408],
+                      [-68.215009, 44.376271],
+                      [-68.214953, 44.376254],
+                      [-68.21468, 44.37631],
+                      [-68.213882, 44.376502],
+                      [-68.213482, 44.376597],
+                      [-68.213243, 44.376655],
+                      [-68.212313, 44.374496],
+                      [-68.211558, 44.372367],
+                      [-68.211399, 44.372288],
+                      [-68.21118, 44.372018],
+                      [-68.210472, 44.37194],
+                      [-68.210246, 44.371184],
+                      [-68.210209, 44.370999],
+                      [-68.209809, 44.3709],
+                      [-68.209674, 44.370872],
+                      [-68.209374, 44.370784],
+                      [-68.208901, 44.370707],
+                      [-68.20848, 44.370619],
+                      [-68.208055, 44.370462],
+                      [-68.207475, 44.370218],
+                      [-68.206693, 44.36991],
+                      [-68.206635, 44.369828],
+                      [-68.206598, 44.369774],
+                      [-68.205274, 44.369088],
+                      [-68.204486, 44.368584],
+                      [-68.204359, 44.368216],
+                      [-68.204252, 44.367661],
+                      [-68.20413, 44.367028],
+                      [-68.204035, 44.366243],
+                      [-68.203683, 44.365923],
+                      [-68.203423, 44.365692],
+                      [-68.203131, 44.365347],
+                      [-68.202994, 44.364962],
+                      [-68.202997, 44.364423],
+                      [-68.203178, 44.363872],
+                      [-68.203326, 44.363205],
+                      [-68.203486, 44.362816],
+                      [-68.203503, 44.362304],
+                      [-68.203458, 44.362079],
+                      [-68.203413, 44.361855],
+                      [-68.203924, 44.361362],
+                      [-68.204259, 44.361089],
+                      [-68.204362, 44.361006],
+                      [-68.204631, 44.36051],
+                      [-68.204815, 44.360041],
+                      [-68.205002, 44.359076],
+                      [-68.205137, 44.358607],
+                      [-68.205091, 44.358525],
+                      [-68.204663, 44.358184],
+                      [-68.2047, 44.358602],
+                      [-68.204637, 44.35895],
+                      [-68.204436, 44.359744],
+                      [-68.204191, 44.360196],
+                      [-68.203266, 44.361148],
+                      [-68.202811, 44.360446],
+                      [-68.202256, 44.35968],
+                      [-68.201729, 44.359066],
+                      [-68.201122, 44.35873],
+                      [-68.200507, 44.358559],
+                      [-68.19982, 44.358614],
+                      [-68.198656, 44.358991],
+                      [-68.197665, 44.359681],
+                      [-68.196749, 44.360609],
+                      [-68.195339, 44.361905],
+                      [-68.194432, 44.362705],
+                      [-68.193851, 44.362872],
+                      [-68.193248, 44.362902],
+                      [-68.19242, 44.362617],
+                      [-68.191831, 44.362252],
+                      [-68.191363, 44.36196],
+                      [-68.191242, 44.361886],
+                      [-68.190669, 44.36157],
+                      [-68.190026, 44.361373],
+                      [-68.189368, 44.361207],
+                      [-68.188838, 44.360918],
+                      [-68.188461, 44.360486],
+                      [-68.188203, 44.36005],
+                      [-68.188005, 44.36011],
+                      [-68.18827, 44.360557],
+                      [-68.188677, 44.361024],
+                      [-68.189265, 44.361345],
+                      [-68.189948, 44.361517],
+                      [-68.19056, 44.361704],
+                      [-68.191106, 44.362005],
+                      [-68.191816, 44.362447],
+                      [-68.192301, 44.362748],
+                      [-68.193207, 44.363059],
+                      [-68.1939, 44.363025],
+                      [-68.194564, 44.362833],
+                      [-68.194902, 44.362535],
+                      [-68.195183, 44.362287],
+                      [-68.195507, 44.362001],
+                      [-68.196922, 44.360701],
+                      [-68.197451, 44.360164],
+                      [-68.197829, 44.359782],
+                      [-68.198779, 44.35912],
+                      [-68.199877, 44.358764],
+                      [-68.200478, 44.358717],
+                      [-68.201015, 44.358866],
+                      [-68.201567, 44.359171],
+                      [-68.202069, 44.359756],
+                      [-68.202617, 44.360512],
+                      [-68.202955, 44.361067],
+                      [-68.203161, 44.36134],
+                      [-68.202159, 44.362043],
+                      [-68.201797, 44.362187],
+                      [-68.201504, 44.362303],
+                      [-68.198986, 44.361073],
+                      [-68.197708, 44.361421],
+                      [-68.196631, 44.36226],
+                      [-68.196508, 44.363085],
+                      [-68.196572, 44.363238],
+                      [-68.196061, 44.363202],
+                      [-68.195768, 44.363209],
+                      [-68.196471, 44.36268],
+                      [-68.196287, 44.362527],
+                      [-68.196213, 44.362585],
+                      [-68.196354, 44.362678],
+                      [-68.19514, 44.363621],
+                      [-68.195132, 44.363954],
+                      [-68.19507, 44.365154],
+                      [-68.195158, 44.365144],
+                      [-68.195171, 44.365072],
+                      [-68.195225, 44.363619],
+                      [-68.195467, 44.363436],
+                      [-68.195294, 44.365176],
+                      [-68.195292, 44.367557],
+                      [-68.197253, 44.36682],
+                      [-68.197395, 44.367601],
+                      [-68.197582, 44.367916],
+                      [-68.197572, 44.368114],
+                      [-68.195496, 44.368819],
+                      [-68.195111, 44.367605],
+                      [-68.194893, 44.367329],
+                      [-68.194844, 44.367267],
+                      [-68.194124, 44.36665],
+                      [-68.194019, 44.366571],
+                      [-68.193674, 44.36631],
+                      [-68.192613, 44.365629],
+                      [-68.191789, 44.365274],
+                      [-68.191651, 44.365215],
+                      [-68.190978, 44.364903],
+                      [-68.190552, 44.364469],
+                      [-68.191831, 44.364443],
+                      [-68.191772, 44.362792],
+                      [-68.19086, 44.362114],
+                      [-68.190551, 44.3622],
+                      [-68.184646, 44.364282],
+                      [-68.184456, 44.364301],
+                      [-68.184232, 44.364272],
+                      [-68.183978, 44.364158],
+                      [-68.183213, 44.363515],
+                      [-68.183043, 44.363291],
+                      [-68.18297, 44.36309],
+                      [-68.182955, 44.362784],
+                      [-68.182607, 44.362662],
+                      [-68.1824, 44.362537],
+                      [-68.182226, 44.362367],
+                      [-68.181996, 44.36198],
+                      [-68.181952, 44.361804],
+                      [-68.181975, 44.36167],
+                      [-68.182103, 44.361561],
+                      [-68.18223, 44.361465],
+                      [-68.18227, 44.361368],
+                      [-68.182354, 44.361155],
+                      [-68.182655, 44.360669],
+                      [-68.18274, 44.360425],
+                      [-68.18277, 44.360233],
+                      [-68.182805, 44.360178],
+                      [-68.182884, 44.360158],
+                      [-68.182996, 44.360149],
+                      [-68.183081, 44.360098],
+                      [-68.183186, 44.359975],
+                      [-68.183296, 44.359671],
+                      [-68.183348, 44.359464],
+                      [-68.18335, 44.359315],
+                      [-68.183329, 44.359264],
+                      [-68.183223, 44.359241],
+                      [-68.183171, 44.359196],
+                      [-68.183184, 44.359113],
+                      [-68.183198, 44.358948],
+                      [-68.183184, 44.358896],
+                      [-68.18315, 44.358882],
+                      [-68.183102, 44.358893],
+                      [-68.18303, 44.358932],
+                      [-68.182948, 44.358946],
+                      [-68.182864, 44.35894],
+                      [-68.182824, 44.358898],
+                      [-68.182796, 44.358628],
+                      [-68.182838, 44.358593],
+                      [-68.182918, 44.358596],
+                      [-68.183061, 44.358626],
+                      [-68.183159, 44.358627],
+                      [-68.183225, 44.3586],
+                      [-68.18325, 44.358551],
+                      [-68.183241, 44.358478],
+                      [-68.183207, 44.358397],
+                      [-68.183192, 44.358329],
+                      [-68.183213, 44.35829],
+                      [-68.183329, 44.358242],
+                      [-68.183429, 44.358187],
+                      [-68.183542, 44.358077],
+                      [-68.183575, 44.357984],
+                      [-68.183576, 44.357823],
+                      [-68.183567, 44.357721],
+                      [-68.183606, 44.35763],
+                      [-68.183674, 44.357546],
+                      [-68.183689, 44.357437],
+                      [-68.183701, 44.357178],
+                      [-68.183609, 44.356869],
+                      [-68.183531, 44.356689],
+                      [-68.183407, 44.35662],
+                      [-68.183335, 44.356559],
+                      [-68.183304, 44.35648],
+                      [-68.183244, 44.356456],
+                      [-68.183191, 44.356422],
+                      [-68.183125, 44.35629],
+                      [-68.183058, 44.356256],
+                      [-68.182958, 44.356222],
+                      [-68.182885, 44.35617],
+                      [-68.182795, 44.356087],
+                      [-68.182689, 44.356036],
+                      [-68.182635, 44.355978],
+                      [-68.182593, 44.355865],
+                      [-68.182574, 44.355676],
+                      [-68.182609, 44.355437],
+                      [-68.182662, 44.355297],
+                      [-68.182674, 44.355218],
+                      [-68.182691, 44.35515],
+                      [-68.182891, 44.354974],
+                      [-68.182632, 44.354734],
+                      [-68.182556, 44.354619],
+                      [-68.182527, 44.35453],
+                      [-68.182527, 44.354435],
+                      [-68.182528, 44.354004],
+                      [-68.182458, 44.353866],
+                      [-68.182432, 44.353761],
+                      [-68.182382, 44.353331],
+                      [-68.18234, 44.353293],
+                      [-68.18227, 44.353284],
+                      [-68.182141, 44.353284],
+                      [-68.18136, 44.353561],
+                      [-68.18124, 44.352952],
+                      [-68.180973, 44.352285],
+                      [-68.18073, 44.351101],
+                      [-68.180498, 44.3501],
+                      [-68.179842, 44.349242],
+                      [-68.179683, 44.349087],
+                      [-68.179522, 44.34893],
+                      [-68.179152, 44.348663],
+                      [-68.179036, 44.348306],
+                      [-68.178792, 44.348028],
+                      [-68.178759, 44.347998],
+                      [-68.180814, 44.346243],
+                      [-68.181126, 44.346636],
+                      [-68.181362, 44.347007],
+                      [-68.181482, 44.347386],
+                      [-68.181573, 44.348333],
+                      [-68.181866, 44.348606],
+                      [-68.181948, 44.348588],
+                      [-68.182039, 44.348567],
+                      [-68.181815, 44.348344],
+                      [-68.181692, 44.347366],
+                      [-68.181562, 44.346959],
+                      [-68.181313, 44.346567],
+                      [-68.180748, 44.345856],
+                      [-68.180244, 44.345221],
+                      [-68.179914, 44.34428],
+                      [-68.179668, 44.343908],
+                      [-68.179563, 44.343749],
+                      [-68.179232, 44.343268],
+                      [-68.179203, 44.34294],
+                      [-68.17966, 44.342413],
+                      [-68.180243, 44.3418],
+                      [-68.18058, 44.341045],
+                      [-68.180378, 44.341073],
+                      [-68.17618, 44.341651],
+                      [-68.176091, 44.340371],
+                      [-68.175495, 44.339566],
+                      [-68.174957, 44.338535],
+                      [-68.174915, 44.338422],
+                      [-68.174675, 44.337776],
+                      [-68.1742, 44.335844],
+                      [-68.17559, 44.333528],
+                      [-68.175681, 44.333371],
+                      [-68.176374, 44.33218],
+                      [-68.176215, 44.331621],
+                      [-68.17585, 44.331063],
+                      [-68.174588, 44.330136],
+                      [-68.173775, 44.329358],
+                      [-68.173391, 44.328682],
+                      [-68.173578, 44.328097],
+                      [-68.174722, 44.327137],
+                      [-68.175519, 44.326145],
+                      [-68.176994, 44.325771],
+                      [-68.177499, 44.32495],
+                      [-68.178326, 44.324887],
+                      [-68.178844, 44.324967],
+                      [-68.179225, 44.325026],
+                      [-68.179366, 44.325861],
+                      [-68.180216, 44.326927],
+                      [-68.1803, 44.328161],
+                      [-68.180479, 44.328611],
+                      [-68.180788, 44.328743],
+                      [-68.183581, 44.328776],
+                      [-68.183838, 44.328393],
+                      [-68.184069, 44.3275],
+                      [-68.184079, 44.327461],
+                      [-68.184217, 44.327162],
+                      [-68.184894, 44.326921],
+                      [-68.185087, 44.326472],
+                      [-68.185459, 44.326512],
+                      [-68.185589, 44.326043],
+                      [-68.185357, 44.325351],
+                      [-68.18556, 44.32481],
+                      [-68.185978, 44.324785],
+                      [-68.185992, 44.323969],
+                      [-68.186213, 44.323122],
+                      [-68.186949, 44.322325],
+                      [-68.187262, 44.321976],
+                      [-68.187643, 44.322014],
+                      [-68.187906, 44.320935],
+                      [-68.188263, 44.320045],
+                      [-68.188978, 44.319322],
+                      [-68.18867, 44.31907],
+                      [-68.188971, 44.318671],
+                      [-68.189141, 44.31798],
+                      [-68.189523, 44.317774],
+                      [-68.190266, 44.317769],
+                      [-68.190473, 44.31754],
+                      [-68.189944, 44.316266],
+                      [-68.18974, 44.315788],
+                      [-68.189769, 44.31524]
+                    ]
+                  ],
+                  "type": "Polygon"
+                },
+                "properties": {
+                  "name": "Acadia National Park",
+                  "venue_type": "National Park"
+                },
+                "type": "Feature"
+              }
+            ],
+            "type": "FeatureCollection"
+          }
+        },
+        "properties": {
+          "found": {
+            "title": "Found",
+            "type": "object"
+          }
+        },
+        "required": ["found"],
+        "title": "VenuePolyResponse",
+        "type": "object"
+      },
+      "VenueRouteResponse": {
+        "example": {
+          "found": {
+            "features": [
+              {
+                "geometry": {
+                  "coordinates": [
+                    [
+                      [-80.337809, 25.463077],
+                      [-80.345712, 25.463044],
+                      [-80.346075, 25.46299],
+                      [-80.346432, 25.462876],
+                      [-80.346612, 25.462876],
+                      [-80.346613, 25.463038],
+                      [-80.346568, 25.463038],
+                      [-80.346602, 25.469724],
+                      [-80.346716, 25.470814],
+                      [-80.346762, 25.478174],
+                      [-80.346785, 25.481925],
+                      [-80.342152, 25.481932],
+                      [-80.342197, 25.489385],
+                      [-80.342199, 25.489798],
+                      [-80.342199, 25.489812],
+                      [-80.342479, 25.493019],
+                      [-80.342496, 25.493212],
+                      [-80.342967, 25.498612],
+                      [-80.338914, 25.507652],
+                      [-80.338869, 25.507748],
+                      [-80.338847, 25.507906],
+                      [-80.338161, 25.512791],
+                      [-80.335172, 25.518247],
+                      [-80.335131, 25.519039],
+                      [-80.335112, 25.519403],
+                      [-80.334967, 25.522213],
+                      [-80.334963, 25.52228],
+                      [-80.335241, 25.529885],
+                      [-80.3315, 25.537094],
+                      [-80.325902, 25.534583],
+                      [-80.32528, 25.534587],
+                      [-80.325086, 25.534819],
+                      [-80.324752, 25.535567],
+                      [-80.324649, 25.535709],
+                      [-80.324467, 25.535775],
+                      [-80.324425, 25.535947],
+                      [-80.324303, 25.536046],
+                      [-80.324091, 25.536013],
+                      [-80.323972, 25.536026],
+                      [-80.324702, 25.537288],
+                      [-80.326498, 25.540392],
+                      [-80.327479, 25.541662],
+                      [-80.328442, 25.542793],
+                      [-80.329161, 25.543451],
+                      [-80.329156, 25.54435],
+                      [-80.324231, 25.544327],
+                      [-80.324215, 25.547078],
+                      [-80.324209, 25.548179],
+                      [-80.323291, 25.549604],
+                      [-80.320578, 25.552041],
+                      [-80.315148, 25.552086],
+                      [-80.313928, 25.552186],
+                      [-80.311264, 25.559549],
+                      [-80.310584, 25.563229],
+                      [-80.31045, 25.56691],
+                      [-80.310425, 25.566953],
+                      [-80.30736, 25.572476],
+                      [-80.307424, 25.577898],
+                      [-80.309494, 25.581724],
+                      [-80.309512, 25.583421],
+                      [-80.309547, 25.585256],
+                      [-80.310829, 25.586414],
+                      [-80.31095, 25.594306],
+                      [-80.310102, 25.594314],
+                      [-80.310163, 25.599704],
+                      [-80.310031, 25.600786],
+                      [-80.309966, 25.600788],
+                      [-80.309907, 25.601375],
+                      [-80.309786, 25.601378],
+                      [-80.309674, 25.602484],
+                      [-80.309671, 25.602508],
+                      [-80.309631, 25.602673],
+                      [-80.30959, 25.60295],
+                      [-80.30956, 25.603196],
+                      [-80.309522, 25.603484],
+                      [-80.309487, 25.603771],
+                      [-80.309505, 25.603827],
+                      [-80.309313, 25.605718],
+                      [-80.309289, 25.605716],
+                      [-80.309281, 25.605717],
+                      [-80.309272, 25.605718],
+                      [-80.309263, 25.605719],
+                      [-80.309254, 25.605721],
+                      [-80.309245, 25.605723],
+                      [-80.309237, 25.605725],
+                      [-80.309228, 25.605727],
+                      [-80.30922, 25.60573],
+                      [-80.309212, 25.605733],
+                      [-80.309203, 25.605736],
+                      [-80.309195, 25.60574],
+                      [-80.309188, 25.605744],
+                      [-80.30918, 25.605748],
+                      [-80.309172, 25.605752],
+                      [-80.309165, 25.605756],
+                      [-80.309157, 25.605761],
+                      [-80.30915, 25.605766],
+                      [-80.309144, 25.605771],
+                      [-80.309137, 25.605777],
+                      [-80.30913, 25.605782],
+                      [-80.309124, 25.605788],
+                      [-80.309118, 25.605794],
+                      [-80.309112, 25.6058],
+                      [-80.309107, 25.605806],
+                      [-80.309102, 25.605813],
+                      [-80.309096, 25.60582],
+                      [-80.309092, 25.605826],
+                      [-80.309087, 25.605833],
+                      [-80.309083, 25.605841],
+                      [-80.309079, 25.605848],
+                      [-80.309075, 25.605855],
+                      [-80.309072, 25.605863],
+                      [-80.309069, 25.60587],
+                      [-80.309066, 25.605878],
+                      [-80.309063, 25.605886],
+                      [-80.309061, 25.605894],
+                      [-80.309059, 25.605902],
+                      [-80.309058, 25.605909],
+                      [-80.309056, 25.605917],
+                      [-80.309055, 25.605926],
+                      [-80.309055, 25.605934],
+                      [-80.309054, 25.605942],
+                      [-80.309054, 25.60595],
+                      [-80.309055, 25.605958],
+                      [-80.309055, 25.605966],
+                      [-80.309056, 25.605974],
+                      [-80.309057, 25.605982],
+                      [-80.309059, 25.60599],
+                      [-80.309061, 25.605998],
+                      [-80.309063, 25.606006],
+                      [-80.309065, 25.606014],
+                      [-80.309068, 25.606021],
+                      [-80.309071, 25.606029],
+                      [-80.309074, 25.606037],
+                      [-80.309078, 25.606044],
+                      [-80.309082, 25.606051],
+                      [-80.309086, 25.606058],
+                      [-80.30909, 25.606065],
+                      [-80.309095, 25.606072],
+                      [-80.3091, 25.606079],
+                      [-80.309105, 25.606086],
+                      [-80.30911, 25.606092],
+                      [-80.309116, 25.606098],
+                      [-80.309122, 25.606104],
+                      [-80.309128, 25.60611],
+                      [-80.309135, 25.606116],
+                      [-80.309141, 25.606121],
+                      [-80.309148, 25.606127],
+                      [-80.309155, 25.606132],
+                      [-80.309162, 25.606136],
+                      [-80.30917, 25.606141],
+                      [-80.309177, 25.606145],
+                      [-80.309185, 25.606149],
+                      [-80.309193, 25.606153],
+                      [-80.309201, 25.606157],
+                      [-80.309209, 25.60616],
+                      [-80.309217, 25.606163],
+                      [-80.309225, 25.606166],
+                      [-80.309234, 25.606169],
+                      [-80.309242, 25.606171],
+                      [-80.309251, 25.606173],
+                      [-80.30926, 25.606175],
+                      [-80.309269, 25.606176],
+                      [-80.309277, 25.606177],
+                      [-80.309286, 25.606178],
+                      [-80.309295, 25.606179],
+                      [-80.309304, 25.606179],
+                      [-80.309313, 25.606179],
+                      [-80.309322, 25.606179],
+                      [-80.309331, 25.606178],
+                      [-80.309507, 25.606193],
+                      [-80.309444, 25.60681],
+                      [-80.309297, 25.606815],
+                      [-80.309246, 25.607229],
+                      [-80.30879, 25.607243],
+                      [-80.308452, 25.607261],
+                      [-80.308464, 25.607389],
+                      [-80.308393, 25.60737],
+                      [-80.308362, 25.607405],
+                      [-80.308328, 25.607458],
+                      [-80.308273, 25.607453],
+                      [-80.308243, 25.607449],
+                      [-80.308218, 25.607471],
+                      [-80.308217, 25.607486],
+                      [-80.308152, 25.607484],
+                      [-80.308145, 25.607508],
+                      [-80.308143, 25.607525],
+                      [-80.308143, 25.607544],
+                      [-80.308162, 25.607555],
+                      [-80.308465, 25.607565],
+                      [-80.308499, 25.607772],
+                      [-80.300113, 25.608044],
+                      [-80.22013, 25.596009],
+                      [-80.211521, 25.629537],
+                      [-80.20098, 25.671116],
+                      [-80.187503, 25.671116],
+                      [-80.17825, 25.671116],
+                      [-80.134279, 25.644928],
+                      [-80.089436, 25.644655],
+                      [-80.08941, 25.644118],
+                      [-80.08951, 25.643422],
+                      [-80.0898, 25.641998],
+                      [-80.090116, 25.640699],
+                      [-80.090459, 25.639518],
+                      [-80.090701, 25.638406],
+                      [-80.090713, 25.638066],
+                      [-80.090571, 25.636745],
+                      [-80.090453, 25.635471],
+                      [-80.090415, 25.634741],
+                      [-80.090436, 25.634531],
+                      [-80.090454, 25.634245],
+                      [-80.090502, 25.633708],
+                      [-80.090936, 25.631613],
+                      [-80.090988, 25.630864],
+                      [-80.091012, 25.630517],
+                      [-80.091063, 25.627558],
+                      [-80.091022, 25.626939],
+                      [-80.091015, 25.626792],
+                      [-80.091007, 25.62665],
+                      [-80.090961, 25.626008],
+                      [-80.090908, 25.625642],
+                      [-80.090932, 25.624121],
+                      [-80.090898, 25.623626],
+                      [-80.090848, 25.62291],
+                      [-80.090974, 25.619916],
+                      [-80.091013, 25.619636],
+                      [-80.091034, 25.619444],
+                      [-80.091169, 25.618696],
+                      [-80.091301, 25.618143],
+                      [-80.091346, 25.617952],
+                      [-80.09156, 25.617575],
+                      [-80.09229, 25.615407],
+                      [-80.092356, 25.614875],
+                      [-80.092365, 25.61432],
+                      [-80.092307, 25.613931],
+                      [-80.092268, 25.613709],
+                      [-80.092224, 25.613426],
+                      [-80.09215, 25.613111],
+                      [-80.092075, 25.612852],
+                      [-80.092015, 25.612634],
+                      [-80.09195, 25.61249],
+                      [-80.091916, 25.612337],
+                      [-80.091861, 25.612189],
+                      [-80.091805, 25.612068],
+                      [-80.091755, 25.611957],
+                      [-80.09168, 25.611813],
+                      [-80.091599, 25.611683],
+                      [-80.091499, 25.61146],
+                      [-80.091232, 25.610954],
+                      [-80.091142, 25.610759],
+                      [-80.091031, 25.610573],
+                      [-80.090864, 25.610392],
+                      [-80.090758, 25.610276],
+                      [-80.090626, 25.610113],
+                      [-80.090413, 25.609889],
+                      [-80.090211, 25.609643],
+                      [-80.089949, 25.609271],
+                      [-80.090027, 25.608156],
+                      [-80.090334, 25.606183],
+                      [-80.090499, 25.605139],
+                      [-80.090509, 25.604368],
+                      [-80.090561, 25.602318],
+                      [-80.090604, 25.601699],
+                      [-80.090684, 25.60129],
+                      [-80.091003, 25.599895],
+                      [-80.091026, 25.599158],
+                      [-80.090875, 25.597128],
+                      [-80.090896, 25.596529],
+                      [-80.090938, 25.5961],
+                      [-80.091018, 25.595667],
+                      [-80.091082, 25.595283],
+                      [-80.091362, 25.594197],
+                      [-80.091394, 25.593896],
+                      [-80.091426, 25.593394],
+                      [-80.091424, 25.592955],
+                      [-80.091575, 25.591877],
+                      [-80.091632, 25.591014],
+                      [-80.091798, 25.589804],
+                      [-80.091937, 25.588806],
+                      [-80.092062, 25.587842],
+                      [-80.09209, 25.587491],
+                      [-80.091998, 25.587053],
+                      [-80.091868, 25.586707],
+                      [-80.09173, 25.586388],
+                      [-80.091588, 25.58611],
+                      [-80.091475, 25.585829],
+                      [-80.091361, 25.585521],
+                      [-80.091281, 25.585176],
+                      [-80.091234, 25.58491],
+                      [-80.091203, 25.584659],
+                      [-80.091213, 25.584356],
+                      [-80.091927, 25.582319],
+                      [-80.092088, 25.581454],
+                      [-80.092098, 25.581122],
+                      [-80.091578, 25.579022],
+                      [-80.091558, 25.578729],
+                      [-80.09168, 25.578184],
+                      [-80.091981, 25.577174],
+                      [-80.092629, 25.575867],
+                      [-80.092689, 25.575721],
+                      [-80.092648, 25.575301],
+                      [-80.092527, 25.574834],
+                      [-80.092329, 25.573881],
+                      [-80.092301, 25.573668],
+                      [-80.092295, 25.573528],
+                      [-80.092303, 25.573382],
+                      [-80.092342, 25.573143],
+                      [-80.092653, 25.5717],
+                      [-80.093274, 25.569235],
+                      [-80.093794, 25.566868],
+                      [-80.093957, 25.565758],
+                      [-80.094065, 25.56506],
+                      [-80.094569, 25.563399],
+                      [-80.09481, 25.562535],
+                      [-80.094796, 25.561523],
+                      [-80.094789, 25.560505],
+                      [-80.094799, 25.560139],
+                      [-80.094952, 25.559248],
+                      [-80.095097, 25.558503],
+                      [-80.095144, 25.558077],
+                      [-80.095146, 25.556826],
+                      [-80.09503, 25.554742],
+                      [-80.094969, 25.553051],
+                      [-80.095008, 25.55182],
+                      [-80.09511, 25.550929],
+                      [-80.095083, 25.550569],
+                      [-80.095093, 25.55033],
+                      [-80.095345, 25.548987],
+                      [-80.095545, 25.547776],
+                      [-80.095586, 25.547191],
+                      [-80.095581, 25.546798],
+                      [-80.095548, 25.546379],
+                      [-80.095455, 25.546085],
+                      [-80.095412, 25.545839],
+                      [-80.095407, 25.545572],
+                      [-80.095431, 25.545366],
+                      [-80.095542, 25.545147],
+                      [-80.095676, 25.544948],
+                      [-80.095743, 25.544742],
+                      [-80.095652, 25.544189],
+                      [-80.095663, 25.543744],
+                      [-80.095653, 25.543138],
+                      [-80.095704, 25.542193],
+                      [-80.095781, 25.541641],
+                      [-80.095992, 25.54093],
+                      [-80.096723, 25.539357],
+                      [-80.096813, 25.539098],
+                      [-80.09684, 25.538366],
+                      [-80.096791, 25.537075],
+                      [-80.0968, 25.536842],
+                      [-80.097221, 25.5356],
+                      [-80.09781, 25.534252],
+                      [-80.098045, 25.533215],
+                      [-80.097779, 25.531629],
+                      [-80.097751, 25.531356],
+                      [-80.097945, 25.529933],
+                      [-80.098234, 25.528577],
+                      [-80.098313, 25.527892],
+                      [-80.098368, 25.527406],
+                      [-80.098571, 25.526762],
+                      [-80.098629, 25.526278],
+                      [-80.09867, 25.525772],
+                      [-80.098651, 25.525273],
+                      [-80.098566, 25.52488],
+                      [-80.098417, 25.52422],
+                      [-80.098231, 25.523573],
+                      [-80.098175, 25.523233],
+                      [-80.09835, 25.522456],
+                      [-80.098599, 25.521499],
+                      [-80.098606, 25.521471],
+                      [-80.098769, 25.521028],
+                      [-80.099011, 25.520285],
+                      [-80.099245, 25.519636],
+                      [-80.099283, 25.519533],
+                      [-80.09945, 25.519124],
+                      [-80.099598, 25.518543],
+                      [-80.099788, 25.517763],
+                      [-80.099957, 25.517131],
+                      [-80.100139, 25.516155],
+                      [-80.100279, 25.515243],
+                      [-80.100542, 25.513832],
+                      [-80.100923, 25.511704],
+                      [-80.101156, 25.51012],
+                      [-80.101525, 25.507253],
+                      [-80.101592, 25.506117],
+                      [-80.101747, 25.505027],
+                      [-80.10195, 25.503963],
+                      [-80.102029, 25.502579],
+                      [-80.102262, 25.500193],
+                      [-80.102423, 25.499591],
+                      [-80.103411, 25.498002],
+                      [-80.104212, 25.497155],
+                      [-80.104882, 25.496473],
+                      [-80.105227, 25.495753],
+                      [-80.105547, 25.494761],
+                      [-80.105788, 25.493958],
+                      [-80.105995, 25.49235],
+                      [-80.106012, 25.488256],
+                      [-80.105841, 25.486823],
+                      [-80.105804, 25.484728],
+                      [-80.105877, 25.483593],
+                      [-80.10651, 25.480934],
+                      [-80.107087, 25.478678],
+                      [-80.107225, 25.477599],
+                      [-80.107475, 25.476281],
+                      [-80.107816, 25.475112],
+                      [-80.108125, 25.474262],
+                      [-80.108425, 25.473402],
+                      [-80.108485, 25.473181],
+                      [-80.108684, 25.47273],
+                      [-80.108873, 25.472269],
+                      [-80.108993, 25.471862],
+                      [-80.109035, 25.471551],
+                      [-80.109047, 25.471267],
+                      [-80.109092, 25.470416],
+                      [-80.109107, 25.469717],
+                      [-80.109135, 25.469265],
+                      [-80.109182, 25.468845],
+                      [-80.109265, 25.4681],
+                      [-80.109336, 25.467754],
+                      [-80.109649, 25.467132],
+                      [-80.110111, 25.466266],
+                      [-80.110346, 25.465803],
+                      [-80.110533, 25.465355],
+                      [-80.110662, 25.465021],
+                      [-80.110764, 25.464607],
+                      [-80.110795, 25.464223],
+                      [-80.110892, 25.463645],
+                      [-80.110967, 25.463191],
+                      [-80.11104, 25.462218],
+                      [-80.111091, 25.4613],
+                      [-80.111147, 25.460456],
+                      [-80.11126, 25.459948],
+                      [-80.111408, 25.45937],
+                      [-80.11166, 25.457938],
+                      [-80.111886, 25.457121],
+                      [-80.112229, 25.456035],
+                      [-80.112506, 25.455003],
+                      [-80.112774, 25.453767],
+                      [-80.113011, 25.452875],
+                      [-80.113423, 25.451859],
+                      [-80.113753, 25.451157],
+                      [-80.114083, 25.450315],
+                      [-80.114252, 25.449727],
+                      [-80.114418, 25.448914],
+                      [-80.114652, 25.447693],
+                      [-80.114703, 25.446779],
+                      [-80.114794, 25.446351],
+                      [-80.114996, 25.445788],
+                      [-80.115243, 25.44515],
+                      [-80.115478, 25.444533],
+                      [-80.115908, 25.443672],
+                      [-80.116015, 25.443278],
+                      [-80.11609, 25.442799],
+                      [-80.116104, 25.44231],
+                      [-80.116126, 25.441626],
+                      [-80.116026, 25.439559],
+                      [-80.115948, 25.438855],
+                      [-80.116012, 25.438456],
+                      [-80.116079, 25.438211],
+                      [-80.116839, 25.436159],
+                      [-80.117003, 25.435591],
+                      [-80.117111, 25.435142],
+                      [-80.117202, 25.434609],
+                      [-80.11741, 25.434016],
+                      [-80.117562, 25.433593],
+                      [-80.117813, 25.43304],
+                      [-80.118215, 25.432249],
+                      [-80.118317, 25.431855],
+                      [-80.118499, 25.430927],
+                      [-80.118744, 25.429012],
+                      [-80.118849, 25.428159],
+                      [-80.118907, 25.42778],
+                      [-80.119008, 25.427476],
+                      [-80.119277, 25.426794],
+                      [-80.119412, 25.4264],
+                      [-80.119542, 25.425862],
+                      [-80.119578, 25.425498],
+                      [-80.119587, 25.425038],
+                      [-80.119607, 25.424439],
+                      [-80.119544, 25.42403],
+                      [-80.119531, 25.423555],
+                      [-80.119539, 25.423221],
+                      [-80.119602, 25.422902],
+                      [-80.119777, 25.422339],
+                      [-80.120149, 25.421752],
+                      [-80.120503, 25.421474],
+                      [-80.120956, 25.421098],
+                      [-80.121433, 25.420631],
+                      [-80.121797, 25.420354],
+                      [-80.122047, 25.420041],
+                      [-80.122314, 25.419628],
+                      [-80.122487, 25.419195],
+                      [-80.122584, 25.418761],
+                      [-80.122665, 25.418218],
+                      [-80.122702, 25.417584],
+                      [-80.122725, 25.416775],
+                      [-80.122684, 25.416381],
+                      [-80.12265, 25.415701],
+                      [-80.122647, 25.415322],
+                      [-80.122656, 25.414903],
+                      [-80.122741, 25.414564],
+                      [-80.122797, 25.414354],
+                      [-80.122909, 25.414051],
+                      [-80.123128, 25.413533],
+                      [-80.123534, 25.412881],
+                      [-80.123877, 25.412159],
+                      [-80.124239, 25.411503],
+                      [-80.124511, 25.411125],
+                      [-80.125145, 25.41012],
+                      [-80.125268, 25.409811],
+                      [-80.125298, 25.409502],
+                      [-80.125198, 25.408872],
+                      [-80.125184, 25.408488],
+                      [-80.125286, 25.408124],
+                      [-80.125425, 25.407835],
+                      [-80.125876, 25.407039],
+                      [-80.126054, 25.406746],
+                      [-80.126288, 25.406268],
+                      [-80.126518, 25.405665],
+                      [-80.12679, 25.404868],
+                      [-80.126943, 25.40432],
+                      [-80.126969, 25.403731],
+                      [-80.12697, 25.402808],
+                      [-80.12705, 25.402404],
+                      [-80.127134, 25.40214],
+                      [-80.127279, 25.401851],
+                      [-80.127503, 25.401343],
+                      [-80.128053, 25.399734],
+                      [-80.128211, 25.399136],
+                      [-80.128387, 25.398403],
+                      [-80.128521, 25.398019],
+                      [-80.128795, 25.397462],
+                      [-80.12933, 25.396377],
+                      [-80.129658, 25.395151],
+                      [-80.129869, 25.394453],
+                      [-80.130193, 25.393726],
+                      [-80.130428, 25.393073],
+                      [-80.130558, 25.39253],
+                      [-80.130521, 25.392375],
+                      [-80.130429, 25.39215],
+                      [-80.130288, 25.391914],
+                      [-80.130158, 25.391704],
+                      [-80.130044, 25.391454],
+                      [-80.130018, 25.391219],
+                      [-80.130036, 25.391064],
+                      [-80.130054, 25.390865],
+                      [-80.130099, 25.39073],
+                      [-80.130144, 25.390581],
+                      [-80.130189, 25.390421],
+                      [-80.130217, 25.390312],
+                      [-80.130501, 25.389784],
+                      [-80.130625, 25.38945],
+                      [-80.130703, 25.389186],
+                      [-80.130765, 25.389012],
+                      [-80.130843, 25.388818],
+                      [-80.130895, 25.388578],
+                      [-80.13093, 25.388316],
+                      [-80.131488, 25.387002],
+                      [-80.131875, 25.386487],
+                      [-80.132104, 25.386084],
+                      [-80.132183, 25.385817],
+                      [-80.132216, 25.385244],
+                      [-80.13228, 25.384552],
+                      [-80.132281, 25.384319],
+                      [-80.132335, 25.38406],
+                      [-80.132453, 25.383848],
+                      [-80.132845, 25.383358],
+                      [-80.133132, 25.38318],
+                      [-80.133353, 25.383081],
+                      [-80.133684, 25.38287],
+                      [-80.134047, 25.38228],
+                      [-80.134175, 25.381761],
+                      [-80.134302, 25.381476],
+                      [-80.134457, 25.381317],
+                      [-80.134593, 25.381198],
+                      [-80.134733, 25.381099],
+                      [-80.134917, 25.381047],
+                      [-80.13524, 25.380975],
+                      [-80.135534, 25.380864],
+                      [-80.135776, 25.380746],
+                      [-80.135923, 25.38066],
+                      [-80.135975, 25.380594],
+                      [-80.13624, 25.380502],
+                      [-80.13646, 25.38041],
+                      [-80.13663, 25.380238],
+                      [-80.136881, 25.379907],
+                      [-80.136949, 25.379727],
+                      [-80.136966, 25.379388],
+                      [-80.136931, 25.379068],
+                      [-80.136845, 25.378875],
+                      [-80.136743, 25.378754],
+                      [-80.136429, 25.378573],
+                      [-80.136312, 25.378546],
+                      [-80.136136, 25.378578],
+                      [-80.135873, 25.37849],
+                      [-80.135486, 25.378268],
+                      [-80.135341, 25.378121],
+                      [-80.135225, 25.37796],
+                      [-80.135145, 25.377767],
+                      [-80.135067, 25.377507],
+                      [-80.135053, 25.37732],
+                      [-80.135048, 25.377067],
+                      [-80.135028, 25.376787],
+                      [-80.135038, 25.376461],
+                      [-80.135048, 25.375969],
+                      [-80.135087, 25.37567],
+                      [-80.135111, 25.375344],
+                      [-80.135114, 25.375051],
+                      [-80.135116, 25.374745],
+                      [-80.13517, 25.374346],
+                      [-80.135231, 25.37394],
+                      [-80.135307, 25.373554],
+                      [-80.135346, 25.373242],
+                      [-80.135399, 25.372996],
+                      [-80.135556, 25.372597],
+                      [-80.13586, 25.37212],
+                      [-80.136215, 25.371663],
+                      [-80.136541, 25.371059],
+                      [-80.136683, 25.370767],
+                      [-80.136757, 25.370541],
+                      [-80.136795, 25.370368],
+                      [-80.136848, 25.370109],
+                      [-80.136886, 25.369936],
+                      [-80.136866, 25.369756],
+                      [-80.136815, 25.369596],
+                      [-80.136758, 25.369456],
+                      [-80.136671, 25.369302],
+                      [-80.136577, 25.369142],
+                      [-80.136454, 25.368922],
+                      [-80.13633, 25.368761],
+                      [-80.136266, 25.368561],
+                      [-80.136245, 25.368381],
+                      [-80.136246, 25.368228],
+                      [-80.136299, 25.368082],
+                      [-80.136462, 25.367817],
+                      [-80.136824, 25.367399],
+                      [-80.137068, 25.367095],
+                      [-80.137149, 25.366935],
+                      [-80.137173, 25.366683],
+                      [-80.137407, 25.365666],
+                      [-80.137597, 25.364808],
+                      [-80.13771, 25.364343],
+                      [-80.137873, 25.364011],
+                      [-80.138635, 25.362644],
+                      [-80.139079, 25.361941],
+                      [-80.139169, 25.361729],
+                      [-80.139281, 25.361397],
+                      [-80.139364, 25.360991],
+                      [-80.139614, 25.359834],
+                      [-80.139683, 25.359429],
+                      [-80.139699, 25.359196],
+                      [-80.139636, 25.358829],
+                      [-80.139595, 25.35849],
+                      [-80.139633, 25.358257],
+                      [-80.139612, 25.358037],
+                      [-80.139592, 25.357771],
+                      [-80.139572, 25.357524],
+                      [-80.13961, 25.357312],
+                      [-80.139744, 25.357046],
+                      [-80.139951, 25.356768],
+                      [-80.140128, 25.356622],
+                      [-80.140341, 25.356477],
+                      [-80.140541, 25.356219],
+                      [-80.140796, 25.355894],
+                      [-80.140922, 25.355635],
+                      [-80.141133, 25.354844],
+                      [-80.141246, 25.354359],
+                      [-80.141462, 25.353888],
+                      [-80.141471, 25.353682],
+                      [-80.141321, 25.353195],
+                      [-80.141491, 25.352863],
+                      [-80.141559, 25.352657],
+                      [-80.141664, 25.352265],
+                      [-80.141844, 25.351674],
+                      [-80.142069, 25.350883],
+                      [-80.142197, 25.350464],
+                      [-80.142286, 25.350218],
+                      [-80.142828, 25.34923],
+                      [-80.143028, 25.348844],
+                      [-80.143051, 25.348798],
+                      [-80.143667, 25.347697],
+                      [-80.144224, 25.346562],
+                      [-80.144623, 25.345599],
+                      [-80.14481, 25.345008],
+                      [-80.145011, 25.344503],
+                      [-80.145138, 25.344165],
+                      [-80.145304, 25.343467],
+                      [-80.145508, 25.342549],
+                      [-80.145735, 25.341545],
+                      [-80.1459, 25.34106],
+                      [-80.146028, 25.340575],
+                      [-80.146133, 25.340243],
+                      [-80.146179, 25.339831],
+                      [-80.146153, 25.339478],
+                      [-80.146148, 25.339112],
+                      [-80.146158, 25.338726],
+                      [-80.145937, 25.337866],
+                      [-80.145874, 25.337426],
+                      [-80.146003, 25.336854],
+                      [-80.146203, 25.336416],
+                      [-80.146397, 25.336005],
+                      [-80.146994, 25.335409],
+                      [-80.147584, 25.334893],
+                      [-80.148124, 25.334151],
+                      [-80.148398, 25.333726],
+                      [-80.148587, 25.332711],
+                      [-80.148918, 25.331453],
+                      [-80.149096, 25.331099],
+                      [-80.149898, 25.329533],
+                      [-80.150334, 25.328559],
+                      [-80.150593, 25.327797],
+                      [-80.150789, 25.327009],
+                      [-80.151198, 25.325822],
+                      [-80.151569, 25.324484],
+                      [-80.151929, 25.323172],
+                      [-80.152254, 25.321417],
+                      [-80.152418, 25.320308],
+                      [-80.152531, 25.319566],
+                      [-80.152612, 25.31906],
+                      [-80.152665, 25.318484],
+                      [-80.152696, 25.318191],
+                      [-80.152766, 25.317996],
+                      [-80.15333, 25.317005],
+                      [-80.153861, 25.31636],
+                      [-80.154208, 25.315617],
+                      [-80.154597, 25.314457],
+                      [-80.154927, 25.313385],
+                      [-80.155078, 25.312711],
+                      [-80.15518, 25.312064],
+                      [-80.155174, 25.311451],
+                      [-80.155052, 25.310865],
+                      [-80.1549, 25.310252],
+                      [-80.154776, 25.309789],
+                      [-80.154428, 25.309246],
+                      [-80.154226, 25.308854],
+                      [-80.154092, 25.308498],
+                      [-80.154045, 25.308152],
+                      [-80.15444, 25.30748],
+                      [-80.154806, 25.30687],
+                      [-80.154856, 25.306621],
+                      [-80.155005, 25.306347],
+                      [-80.155251, 25.306038],
+                      [-80.155595, 25.30572],
+                      [-80.156391, 25.304979],
+                      [-80.15674, 25.304671],
+                      [-80.156956, 25.304459],
+                      [-80.15735, 25.304009],
+                      [-80.158059, 25.303072],
+                      [-80.160121, 25.299898],
+                      [-80.161794, 25.297245],
+                      [-80.162181, 25.296448],
+                      [-80.162467, 25.295917],
+                      [-80.163444, 25.294476],
+                      [-80.163789, 25.293954],
+                      [-80.164135, 25.293362],
+                      [-80.164403, 25.292724],
+                      [-80.164601, 25.292219],
+                      [-80.165148, 25.291436],
+                      [-80.19904, 25.32534],
+                      [-80.210076, 25.336383],
+                      [-80.243863, 25.335302],
+                      [-80.244443, 25.335615],
+                      [-80.244822, 25.335872],
+                      [-80.245356, 25.336272],
+                      [-80.245785, 25.336616],
+                      [-80.246054, 25.336916],
+                      [-80.24628, 25.337248],
+                      [-80.246689, 25.337795],
+                      [-80.246855, 25.338164],
+                      [-80.247076, 25.338861],
+                      [-80.247365, 25.339568],
+                      [-80.247474, 25.34006],
+                      [-80.247618, 25.34045],
+                      [-80.247763, 25.340696],
+                      [-80.24829, 25.341077],
+                      [-80.248918, 25.34151],
+                      [-80.2495, 25.342035],
+                      [-80.250121, 25.342466],
+                      [-80.251338, 25.3437],
+                      [-80.252395, 25.344849],
+                      [-80.252881, 25.345457],
+                      [-80.253562, 25.346059],
+                      [-80.253839, 25.346337],
+                      [-80.254174, 25.347375],
+                      [-80.254515, 25.348298],
+                      [-80.254673, 25.348759],
+                      [-80.254838, 25.349374],
+                      [-80.254978, 25.349927],
+                      [-80.255236, 25.350504],
+                      [-80.255546, 25.350928],
+                      [-80.255932, 25.351444],
+                      [-80.256486, 25.351876],
+                      [-80.282457, 25.36649],
+                      [-80.310704, 25.372619],
+                      [-80.31497, 25.367037],
+                      [-80.315484, 25.373624],
+                      [-80.331726, 25.37713],
+                      [-80.331641, 25.38911],
+                      [-80.331536, 25.403928],
+                      [-80.331432, 25.418745],
+                      [-80.325844, 25.418801],
+                      [-80.322301, 25.418836],
+                      [-80.323036, 25.425817],
+                      [-80.323089, 25.425926],
+                      [-80.323139, 25.426037],
+                      [-80.323184, 25.42615],
+                      [-80.323225, 25.426264],
+                      [-80.323262, 25.426379],
+                      [-80.323294, 25.426495],
+                      [-80.323322, 25.426612],
+                      [-80.323346, 25.42673],
+                      [-80.323365, 25.426848],
+                      [-80.32338, 25.426967],
+                      [-80.32339, 25.427087],
+                      [-80.323396, 25.427206],
+                      [-80.323398, 25.427326],
+                      [-80.323395, 25.427446],
+                      [-80.323387, 25.427565],
+                      [-80.323375, 25.427685],
+                      [-80.323359, 25.427804],
+                      [-80.323338, 25.427922],
+                      [-80.323313, 25.428039],
+                      [-80.323283, 25.428156],
+                      [-80.323249, 25.428272],
+                      [-80.323211, 25.428387],
+                      [-80.323168, 25.4285],
+                      [-80.323122, 25.428612],
+                      [-80.317148, 25.435865],
+                      [-80.317074, 25.435958],
+                      [-80.317004, 25.436053],
+                      [-80.316937, 25.436151],
+                      [-80.316874, 25.436251],
+                      [-80.316815, 25.436352],
+                      [-80.31676, 25.436456],
+                      [-80.316709, 25.436561],
+                      [-80.316662, 25.436667],
+                      [-80.316619, 25.436775],
+                      [-80.31658, 25.436884],
+                      [-80.316546, 25.436995],
+                      [-80.316515, 25.437106],
+                      [-80.316489, 25.437219],
+                      [-80.316468, 25.437332],
+                      [-80.31645, 25.437445],
+                      [-80.316437, 25.43756],
+                      [-80.316429, 25.437674],
+                      [-80.316424, 25.437789],
+                      [-80.316424, 25.437904],
+                      [-80.316429, 25.438019],
+                      [-80.316438, 25.438133],
+                      [-80.316451, 25.438247],
+                      [-80.316469, 25.438361],
+                      [-80.316491, 25.438474],
+                      [-80.316517, 25.438586],
+                      [-80.316548, 25.438698],
+                      [-80.316583, 25.438808],
+                      [-80.316622, 25.438917],
+                      [-80.316665, 25.439025],
+                      [-80.316712, 25.439132],
+                      [-80.316764, 25.439236],
+                      [-80.316819, 25.43934],
+                      [-80.316879, 25.439441],
+                      [-80.316942, 25.439541],
+                      [-80.317009, 25.439638],
+                      [-80.317079, 25.439733],
+                      [-80.317153, 25.439826],
+                      [-80.317231, 25.439917],
+                      [-80.317312, 25.440005],
+                      [-80.317397, 25.44009],
+                      [-80.317484, 25.440173],
+                      [-80.317575, 25.440253],
+                      [-80.317669, 25.44033],
+                      [-80.317766, 25.440404],
+                      [-80.317865, 25.440475],
+                      [-80.317967, 25.440542],
+                      [-80.318072, 25.440607],
+                      [-80.318179, 25.440668],
+                      [-80.318288, 25.440726],
+                      [-80.3184, 25.44078],
+                      [-80.318513, 25.44083],
+                      [-80.318629, 25.440878],
+                      [-80.318746, 25.440921],
+                      [-80.318864, 25.440961],
+                      [-80.318985, 25.440996],
+                      [-80.319106, 25.441028],
+                      [-80.319229, 25.441057],
+                      [-80.319352, 25.441081],
+                      [-80.319477, 25.441101],
+                      [-80.319602, 25.441118],
+                      [-80.319727, 25.44113],
+                      [-80.319854, 25.441139],
+                      [-80.31998, 25.441143],
+                      [-80.320106, 25.441144],
+                      [-80.320233, 25.44114],
+                      [-80.320359, 25.441133],
+                      [-80.320485, 25.441121],
+                      [-80.325287, 25.440609],
+                      [-80.327323, 25.44229],
+                      [-80.32746, 25.446469],
+                      [-80.347199, 25.446431],
+                      [-80.347189, 25.448023],
+                      [-80.347188, 25.448292],
+                      [-80.347188, 25.448396],
+                      [-80.347192, 25.449434],
+                      [-80.339597, 25.450639],
+                      [-80.339733, 25.451009],
+                      [-80.34022, 25.452353],
+                      [-80.340918, 25.454052],
+                      [-80.341738, 25.455692],
+                      [-80.342663, 25.457274],
+                      [-80.343698, 25.458805],
+                      [-80.344891, 25.460249],
+                      [-80.344661, 25.460422],
+                      [-80.344649, 25.46041],
+                      [-80.344637, 25.460398],
+                      [-80.344624, 25.460386],
+                      [-80.344611, 25.460375],
+                      [-80.344597, 25.460364],
+                      [-80.344583, 25.460353],
+                      [-80.344569, 25.460343],
+                      [-80.344554, 25.460334],
+                      [-80.344539, 25.460325],
+                      [-80.344523, 25.460316],
+                      [-80.344507, 25.460308],
+                      [-80.344491, 25.460301],
+                      [-80.344475, 25.460294],
+                      [-80.344458, 25.460287],
+                      [-80.344441, 25.460281],
+                      [-80.344424, 25.460276],
+                      [-80.344406, 25.460271],
+                      [-80.344389, 25.460267],
+                      [-80.344371, 25.460263],
+                      [-80.344353, 25.46026],
+                      [-80.344335, 25.460257],
+                      [-80.344317, 25.460255],
+                      [-80.344299, 25.460253],
+                      [-80.344281, 25.460253],
+                      [-80.344263, 25.460252],
+                      [-80.344245, 25.460252],
+                      [-80.344226, 25.460253],
+                      [-80.344208, 25.460255],
+                      [-80.34419, 25.460257],
+                      [-80.344172, 25.460259],
+                      [-80.344154, 25.460262],
+                      [-80.344137, 25.460266],
+                      [-80.344119, 25.46027],
+                      [-80.344102, 25.460275],
+                      [-80.344084, 25.46028],
+                      [-80.344067, 25.460286],
+                      [-80.344051, 25.460292],
+                      [-80.344034, 25.460299],
+                      [-80.344018, 25.460307],
+                      [-80.344002, 25.460315],
+                      [-80.343986, 25.460323],
+                      [-80.343971, 25.460332],
+                      [-80.343956, 25.460342],
+                      [-80.343942, 25.460351],
+                      [-80.343927, 25.460362],
+                      [-80.343914, 25.460373],
+                      [-80.3439, 25.460384],
+                      [-80.343887, 25.460395],
+                      [-80.343875, 25.460407],
+                      [-80.343863, 25.46042],
+                      [-80.343852, 25.460433],
+                      [-80.343841, 25.460446],
+                      [-80.34383, 25.460459],
+                      [-80.34382, 25.460473],
+                      [-80.343811, 25.460487],
+                      [-80.343802, 25.460502],
+                      [-80.343793, 25.460516],
+                      [-80.343786, 25.460531],
+                      [-80.343779, 25.460546],
+                      [-80.343772, 25.460562],
+                      [-80.343766, 25.460577],
+                      [-80.343761, 25.460593],
+                      [-80.343756, 25.460609],
+                      [-80.343752, 25.460625],
+                      [-80.343748, 25.460641],
+                      [-80.343745, 25.460658],
+                      [-80.343743, 25.460674],
+                      [-80.343741, 25.46069],
+                      [-80.34374, 25.460707],
+                      [-80.34374, 25.460723],
+                      [-80.34374, 25.46074],
+                      [-80.343741, 25.460756],
+                      [-80.343742, 25.460773],
+                      [-80.343745, 25.460789],
+                      [-80.343747, 25.460806],
+                      [-80.343751, 25.460822],
+                      [-80.343755, 25.460838],
+                      [-80.343759, 25.460854],
+                      [-80.343765, 25.46087],
+                      [-80.34377, 25.460885],
+                      [-80.343777, 25.460901],
+                      [-80.343784, 25.460916],
+                      [-80.343792, 25.460931],
+                      [-80.3438, 25.460946],
+                      [-80.343808, 25.46096],
+                      [-80.343818, 25.460974],
+                      [-80.343828, 25.460988],
+                      [-80.343838, 25.461002],
+                      [-80.343849, 25.461015],
+                      [-80.34386, 25.461028],
+                      [-80.343722, 25.46134],
+                      [-80.337332, 25.459139],
+                      [-80.332348, 25.459116],
+                      [-80.332283, 25.459201],
+                      [-80.33222, 25.459287],
+                      [-80.332162, 25.459376],
+                      [-80.332106, 25.459466],
+                      [-80.332054, 25.459558],
+                      [-80.332006, 25.459652],
+                      [-80.331961, 25.459747],
+                      [-80.331919, 25.459843],
+                      [-80.331882, 25.459941],
+                      [-80.331848, 25.460039],
+                      [-80.331817, 25.460139],
+                      [-80.331791, 25.460239],
+                      [-80.331768, 25.460341],
+                      [-80.331749, 25.460443],
+                      [-80.331734, 25.460545],
+                      [-80.331723, 25.460648],
+                      [-80.331716, 25.460751],
+                      [-80.331712, 25.460854],
+                      [-80.331713, 25.460958],
+                      [-80.331763, 25.463103],
+                      [-80.337809, 25.463077]
+                    ]
+                  ],
+                  "type": "Polygon"
+                },
+                "properties": {
+                  "name": "Biscayne National Park",
+                  "venue_type": "National Park"
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [
+                    [
+                      [-80.35865, 25.45216],
+                      [-80.35889, 25.447743],
+                      [-80.359609, 25.443368],
+                      [-80.360799, 25.439077],
+                      [-80.362449, 25.434913],
+                      [-80.364543, 25.430914],
+                      [-80.367061, 25.42712],
+                      [-80.369979, 25.423567],
+                      [-80.373268, 25.420289],
+                      [-80.376897, 25.417318],
+                      [-80.380831, 25.414683],
+                      [-80.385032, 25.412408],
+                      [-80.38946, 25.410517],
+                      [-80.394072, 25.409027],
+                      [-80.398823, 25.407952],
+                      [-80.403668, 25.407302],
+                      [-80.40856, 25.407085],
+                      [-80.413452, 25.407302],
+                      [-80.418297, 25.407952],
+                      [-80.423048, 25.409027],
+                      [-80.42766, 25.410517],
+                      [-80.432088, 25.412408],
+                      [-80.436289, 25.414683],
+                      [-80.440223, 25.417318],
+                      [-80.443852, 25.420289],
+                      [-80.447141, 25.423567],
+                      [-80.450059, 25.42712],
+                      [-80.452577, 25.430914],
+                      [-80.454671, 25.434913],
+                      [-80.456321, 25.439077],
+                      [-80.457511, 25.443368],
+                      [-80.45823, 25.447743],
+                      [-80.45847, 25.45216],
+                      [-80.45823, 25.456577],
+                      [-80.457511, 25.460952],
+                      [-80.456321, 25.465241],
+                      [-80.454671, 25.469405],
+                      [-80.452577, 25.473402],
+                      [-80.450059, 25.477195],
+                      [-80.447141, 25.480746],
+                      [-80.443852, 25.484022],
+                      [-80.440223, 25.486992],
+                      [-80.436289, 25.489625],
+                      [-80.432088, 25.491898],
+                      [-80.42766, 25.493789],
+                      [-80.423048, 25.495278],
+                      [-80.418297, 25.496352],
+                      [-80.413452, 25.497001],
+                      [-80.40856, 25.497218],
+                      [-80.403668, 25.497001],
+                      [-80.398823, 25.496352],
+                      [-80.394072, 25.495278],
+                      [-80.38946, 25.493789],
+                      [-80.385032, 25.491898],
+                      [-80.380831, 25.489625],
+                      [-80.376897, 25.486992],
+                      [-80.373268, 25.484022],
+                      [-80.369979, 25.480746],
+                      [-80.367061, 25.477195],
+                      [-80.364543, 25.473402],
+                      [-80.362449, 25.469405],
+                      [-80.360799, 25.465241],
+                      [-80.359609, 25.460952],
+                      [-80.35889, 25.456577],
+                      [-80.35865, 25.45216]
+                    ]
+                  ],
+                  "type": "Polygon"
+                },
+                "properties": {
+                  "name": "Homestead-Miami Speedway",
+                  "venue_type": "NASCAR Raceway"
+                },
+                "type": "Feature"
+              }
+            ],
+            "type": "FeatureCollection"
+          }
+        },
+        "properties": {
+          "found": {
+            "title": "Found",
+            "type": "object"
+          }
+        },
+        "required": ["found"],
+        "title": "VenueRouteResponse",
+        "type": "object"
+      },
+      "VenuesByDistance": {
+        "description": "Geometry-defining arguments for point/distance requests",
+        "example": {
+          "distance": 2000,
+          "latitude": 32.75,
+          "longitude": -97.09
+        },
+        "properties": {
+          "distance": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Distance"
+          },
+          "latitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Latitude"
+          },
+          "longitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Longitude"
+          }
+        },
+        "required": ["longitude", "latitude", "distance"],
+        "title": "VenuesByDistance",
+        "type": "object"
+      },
+      "VenuesByPolygon": {
+        "description": "Geometry-defining arguments for polygon requests",
+        "example": {
+          "poly": {
+            "coordinates": [
+              [
+                [-68.26861381530762, 44.36801121434667],
+                [-68.26221942901611, 44.36006491796501],
+                [-68.25882911682127, 44.36561823465291],
+                [-68.26861381530762, 44.36801121434667]
+              ]
+            ],
+            "type": "Polygon"
+          }
+        },
+        "properties": {
+          "poly": {
+            "title": "Poly",
+            "type": "object"
+          }
+        },
+        "required": ["poly"],
+        "title": "VenuesByPolygon",
+        "type": "object"
+      },
+      "VenuesByRoute": {
+        "description": "Geometry-defining arguments for along-route requests",
+        "example": {
+          "route": {
+            "coordinates": [
+              [-80.3798, 25.4551],
+              [-80.3479, 25.489],
+              [-80.3129, 25.4696]
+            ],
+            "type": "LineString"
+          }
+        },
+        "properties": {
+          "route": {
+            "title": "Route",
+            "type": "object"
+          }
+        },
+        "required": ["route"],
+        "title": "VenuesByRoute",
+        "type": "object"
+      },
+      "WxByDistance": {
+        "description": "Geometry-defining arguments for point/distance requests",
+        "example": {
+          "distance": 5000,
+          "hours": 2,
+          "latitude": 37.871,
+          "longitude": -122.283,
+          "wxtypes": ["VIS", "SKY"]
+        },
+        "properties": {
+          "distance": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Distance"
+          },
+          "hours": {
+            "title": "Hours",
+            "type": "integer"
+          },
+          "latitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Latitude"
+          },
+          "longitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Longitude"
+          },
+          "wxtypes": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Wxtypes",
+            "type": "array"
+          }
+        },
+        "required": ["longitude", "latitude", "distance", "wxtypes", "hours"],
+        "title": "WxByDistance",
+        "type": "object"
+      },
+      "WxByPolygon": {
+        "description": "Geometry-defining arguments for polygon requests",
+        "example": {
+          "hours": 5,
+          "poly": {
+            "coordinates": [
+              [
+                [-90.621, 41.505],
+                [-90.599, 41.498],
+                [-90.514, 41.508],
+                [-90.501, 41.523],
+                [-90.543, 41.538],
+                [-90.621, 41.505]
+              ]
+            ],
+            "type": "Polygon"
+          },
+          "wxtypes": ["TEMP", "DEWPT"]
+        },
+        "properties": {
+          "hours": {
+            "title": "Hours",
+            "type": "integer"
+          },
+          "poly": {
+            "title": "Poly",
+            "type": "object"
+          },
+          "wxtypes": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Wxtypes",
+            "type": "array"
+          }
+        },
+        "required": ["poly", "wxtypes", "hours"],
+        "title": "WxByPolygon",
+        "type": "object"
+      },
+      "WxByRoute": {
+        "description": "Geometry-defining arguments for along-route requests",
+        "example": {
+          "hours": 4,
+          "route": {
+            "coordinates": [
+              [-86.247, 43.058],
+              [-86.214, 43.076],
+              [-86.203, 43.089],
+              [-86.192, 43.083],
+              [-86.185, 43.11]
+            ],
+            "type": "LineString"
+          },
+          "wxtypes": ["WINDDIR", "WINDSPEED"]
+        },
+        "properties": {
+          "hours": {
+            "title": "Hours",
+            "type": "integer"
+          },
+          "route": {
+            "title": "Route",
+            "type": "object"
+          },
+          "wxtypes": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Wxtypes",
+            "type": "array"
+          }
+        },
+        "required": ["route", "wxtypes", "hours"],
+        "title": "WxByRoute",
+        "type": "object"
+      },
+      "WxDistanceResponse": {
+        "example": {
+          "found": {
+            "features": [
+              {
+                "geometry": {
+                  "coordinates": [-122.282833, 37.838227],
+                  "type": "Point"
+                },
+                "properties": {
+                  "hour": ["DEC 31 2022 16:00", "DEC 31 2022 17:00"],
+                  "sky": [100, 100],
+                  "vis": [2641, 2641]
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-122.31607, 37.855575],
+                  "type": "Point"
+                },
+                "properties": {
+                  "hour": ["DEC 31 2022 16:00", "DEC 31 2022 17:00"],
+                  "sky": [100, 100],
+                  "vis": [2641, 2641]
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-122.288465, 37.860024],
+                  "type": "Point"
+                },
+                "properties": {
+                  "hour": ["DEC 31 2022 16:00", "DEC 31 2022 17:00"],
+                  "sky": [100, 100],
+                  "vis": [2641, 2641]
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-122.260858, 37.864469],
+                  "type": "Point"
+                },
+                "properties": {
+                  "hour": ["DEC 31 2022 16:00", "DEC 31 2022 17:00"],
+                  "sky": [100, 100],
+                  "vis": [3281, 2641]
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-122.32171, 37.877369],
+                  "type": "Point"
+                },
+                "properties": {
+                  "hour": ["DEC 31 2022 16:00", "DEC 31 2022 17:00"],
+                  "sky": [100, 100],
+                  "vis": [2641, 2641]
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-122.294099, 37.881819],
+                  "type": "Point"
+                },
+                "properties": {
+                  "hour": ["DEC 31 2022 16:00", "DEC 31 2022 17:00"],
+                  "sky": [100, 100],
+                  "vis": [3281, 3281]
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-122.266486, 37.886264],
+                  "type": "Point"
+                },
+                "properties": {
+                  "hour": ["DEC 31 2022 16:00", "DEC 31 2022 17:00"],
+                  "sky": [100, 100],
+                  "vis": [3281, 3281]
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-122.299735, 37.903611],
+                  "type": "Point"
+                },
+                "properties": {
+                  "hour": ["DEC 31 2022 16:00", "DEC 31 2022 17:00"],
+                  "sky": [100, 100],
+                  "vis": [3281, 3281]
+                },
+                "type": "Feature"
+              }
+            ],
+            "type": "FeatureCollection"
+          }
+        },
+        "properties": {
+          "found": {
+            "title": "Found",
+            "type": "object"
+          }
+        },
+        "required": ["found"],
+        "title": "WxDistanceResponse",
+        "type": "object"
+      },
+      "WxPolyResponse": {
+        "example": {
+          "found": {
+            "features": [
+              {
+                "geometry": {
+                  "coordinates": [-90.59314, 41.514363],
+                  "type": "Point"
+                },
+                "properties": {
+                  "dewpt": [-4.91, -3.86, -2.4, -1.54, -0.81],
+                  "hour": [
+                    "DEC 31 2022 16:00",
+                    "DEC 31 2022 17:00",
+                    "DEC 31 2022 18:00",
+                    "DEC 31 2022 19:00",
+                    "DEC 31 2022 20:00"
+                  ],
+                  "temp": [-2.91, -0.52, 2.51, 3.74, 3.8]
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-90.563976, 41.51365],
+                  "type": "Point"
+                },
+                "properties": {
+                  "dewpt": [-4.91, -3.86, -2.4, -1.54, -0.81],
+                  "hour": [
+                    "DEC 31 2022 16:00",
+                    "DEC 31 2022 17:00",
+                    "DEC 31 2022 18:00",
+                    "DEC 31 2022 19:00",
+                    "DEC 31 2022 20:00"
+                  ],
+                  "temp": [-2.91, -0.52, 2.51, 3.74, 3.8]
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-90.534812, 41.512933],
+                  "type": "Point"
+                },
+                "properties": {
+                  "dewpt": [-4.91, -3.86, -2.4, -1.54, -0.81],
+                  "hour": [
+                    "DEC 31 2022 16:00",
+                    "DEC 31 2022 17:00",
+                    "DEC 31 2022 18:00",
+                    "DEC 31 2022 19:00",
+                    "DEC 31 2022 20:00"
+                  ],
+                  "temp": [-2.51, -0.52, 2.51, 3.74, 3.8]
+                },
+                "type": "Feature"
+              }
+            ],
+            "type": "FeatureCollection"
+          }
+        },
+        "properties": {
+          "found": {
+            "title": "Found",
+            "type": "object"
+          }
+        },
+        "required": ["found"],
+        "title": "WxPolyResponse",
+        "type": "object"
+      },
+      "WxRouteResponse": {
+        "example": {
+          "found": {
+            "features": [
+              {
+                "geometry": {
+                  "coordinates": [-86.252478, 43.057319],
+                  "type": "Point"
+                },
+                "properties": {
+                  "hour": [
+                    "DEC 31 2022 16:00",
+                    "DEC 31 2022 17:00",
+                    "DEC 31 2022 18:00",
+                    "DEC 31 2022 19:00"
+                  ],
+                  "winddir": [270, 270, 270, 270],
+                  "windspeed": [2, 2, 2.4, 2]
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-86.22099, 43.077526],
+                  "type": "Point"
+                },
+                "properties": {
+                  "hour": [
+                    "DEC 31 2022 16:00",
+                    "DEC 31 2022 17:00",
+                    "DEC 31 2022 18:00",
+                    "DEC 31 2022 19:00"
+                  ],
+                  "winddir": [310, 300, 290, 280],
+                  "windspeed": [1.2, 1.6, 2, 2]
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-86.191414, 43.076122],
+                  "type": "Point"
+                },
+                "properties": {
+                  "hour": [
+                    "DEC 31 2022 16:00",
+                    "DEC 31 2022 17:00",
+                    "DEC 31 2022 18:00",
+                    "DEC 31 2022 19:00"
+                  ],
+                  "winddir": [300, 280, 270, 280],
+                  "windspeed": [2, 2, 2.4, 2]
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-86.18949, 43.097724],
+                  "type": "Point"
+                },
+                "properties": {
+                  "hour": [
+                    "DEC 31 2022 16:00",
+                    "DEC 31 2022 17:00",
+                    "DEC 31 2022 18:00",
+                    "DEC 31 2022 19:00"
+                  ],
+                  "winddir": [320, 310, 290, 280],
+                  "windspeed": [1.2, 1.6, 2, 2]
+                },
+                "type": "Feature"
+              },
+              {
+                "geometry": {
+                  "coordinates": [-86.187564, 43.119323],
+                  "type": "Point"
+                },
+                "properties": {
+                  "hour": [
+                    "DEC 31 2022 16:00",
+                    "DEC 31 2022 17:00",
+                    "DEC 31 2022 18:00",
+                    "DEC 31 2022 19:00"
+                  ],
+                  "winddir": [320, 310, 290, 280],
+                  "windspeed": [1.2, 1.6, 2, 2]
+                },
+                "type": "Feature"
+              }
+            ],
+            "type": "FeatureCollection"
+          }
+        },
+        "properties": {
+          "found": {
+            "title": "Found",
+            "type": "object"
+          }
+        },
+        "required": ["found"],
+        "title": "WxRouteResponse",
+        "type": "object"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.1.1",
-    "@appear.sh/oas-zod-validator": "1.6.1",
+    "@appear.sh/oas-zod-validator": "1.8.1",
     "@next/third-parties": "^15.3.1",
     "@radix-ui/react-checkbox": "^1.2.3",
     "@radix-ui/react-dialog": "^1.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^10.1.1
         version: 10.1.1(openapi-types@12.1.3)
       '@appear.sh/oas-zod-validator':
-        specifier: 1.6.1
-        version: 1.6.1(@types/node@20.19.11)
+        specifier: 1.8.1
+        version: 1.8.1(@types/node@20.19.11)
       '@next/third-parties':
         specifier: ^15.3.1
         version: 15.5.0(next@15.5.7(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
@@ -152,8 +152,8 @@ packages:
     peerDependencies:
       openapi-types: '>=7'
 
-  '@appear.sh/oas-zod-validator@1.6.1':
-    resolution: {integrity: sha512-OoRTV2O2shicfZ58v8TcagC0wCvx5imx2au8I0zk7Ie8wnjsqNMehPvYG5jRCwMwGOWGefr5tUn6I8wHjBC+jQ==}
+  '@appear.sh/oas-zod-validator@1.8.1':
+    resolution: {integrity: sha512-n26Vq5fBYRMlmMH1KI6VvZu1mEH+bgQ/s9cIFqo6sGrWk2vkDezb+dA4rmLV8JyzGbNS858tyQlTS2Vw5CMAyw==}
     hasBin: true
 
   '@asyncapi/specs@6.10.0':
@@ -3004,7 +3004,7 @@ snapshots:
       call-me-maybe: 1.0.2
       openapi-types: 12.1.3
 
-  '@appear.sh/oas-zod-validator@1.6.1(@types/node@20.19.11)':
+  '@appear.sh/oas-zod-validator@1.8.1(@types/node@20.19.11)':
     dependencies:
       chalk: 4.1.2
       commander: 13.1.0

--- a/src/app/api/validate-url/route.ts
+++ b/src/app/api/validate-url/route.ts
@@ -3,7 +3,7 @@ import { Spectral } from '@stoplight/spectral-core';
 import { oas } from '@stoplight/spectral-rulesets';
 import yaml from 'js-yaml';
 import SwaggerParser from '@apidevtools/swagger-parser';
-import { validateOpenAPIDocument, LocatedValidationResult, LocatedZodIssue } from '@appear.sh/oas-zod-validator';
+import { validateOpenAPIDocument } from '@appear.sh/oas-zod-validator';
 import { ZodError } from 'zod';
 import type { ValidationResult } from '@/lib/types';
 
@@ -217,20 +217,44 @@ export async function POST(request: Request) {
     validatorTasks.push((async () => {
       try {
         if (isDev) console.log('Running OAS Zod Validator with validateOpenAPIDocument...');
-        const oasZodResult: LocatedValidationResult = await validateOpenAPIDocument(fileContent);
+        const oasZodResult = await validateOpenAPIDocument(fileContent);
         if (isDev) console.log(`OAS Zod Validator valid: ${oasZodResult.valid}`);
         if (!oasZodResult.valid && oasZodResult.errors instanceof ZodError) {
-          const mapped = oasZodResult.errors.issues.map((issue: LocatedZodIssue) => ({
-            source: 'OAS Zod Validator',
-            code: issue.code,
-            message: issue.message,
-            severity: 'error' as ValidationResult['severity'],
-            path: issue.path.map(String),
-            range: issue.range ? {
-              start: { line: issue.range.start.line, character: issue.range.start.column },
-              end: { line: issue.range.end.line, character: issue.range.end.column },
-            } : undefined,
-          }));
+          const mapped = oasZodResult.errors.issues.map((issue: unknown) => {
+            // Type assertion for enhanced properties (v1.8.1+)
+            const enhancedIssue = issue as {
+              code: string;
+              message: string;
+              path: (string | number)[];
+              errorCode?: string;
+              suggestion?: string;
+              specLink?: string;
+              category?: string;
+              severity?: 'error' | 'warning';
+              range?: {
+                start: { line: number; column: number };
+                end: { line: number; column: number };
+              };
+            };
+            
+            return {
+              source: 'OAS Zod Validator',
+              code: enhancedIssue.code,
+              message: enhancedIssue.message,
+              // Use enhanced severity if available, otherwise default to 'error'
+              severity: (enhancedIssue.severity || 'error') as ValidationResult['severity'],
+              path: enhancedIssue.path.map(String),
+              range: enhancedIssue.range ? {
+                start: { line: enhancedIssue.range.start.line, character: enhancedIssue.range.start.column },
+                end: { line: enhancedIssue.range.end.line, character: enhancedIssue.range.end.column },
+              } : undefined,
+              // Enhanced properties from v1.8.1+
+              errorCode: enhancedIssue.errorCode,
+              suggestion: enhancedIssue.suggestion,
+              specLink: enhancedIssue.specLink,
+              category: enhancedIssue.category,
+            };
+          });
           return mapped;
         } else if (!oasZodResult.valid) {
           return [{

--- a/src/components/visual-validator.tsx
+++ b/src/components/visual-validator.tsx
@@ -135,7 +135,7 @@ function IssueMarker({
               : "border-zinc-500/50 bg-zinc-900"
       )}>
         <div className="space-y-1">
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 flex-wrap">
             <span
               className={`text-xs px-1.5 py-0.5 rounded-full ${getValidatorColor(
                 issue.source,
@@ -148,15 +148,26 @@ function IssueMarker({
             >
               {issue.severity}
             </span>
+            {issue.category && (
+              <span className="text-xs px-1.5 py-0.5 bg-zinc-700 rounded text-gray-300">
+                {issue.category}
+              </span>
+            )}
           </div>
           <p className="font-medium text-sm text-gray-100">{issue.message}</p>
+          {issue.suggestion && (
+            <div className="mt-1 p-2 bg-zinc-800/50 rounded border-l-2 border-blue-500/50">
+              <p className="text-xs font-semibold text-blue-300 mb-0.5">Suggestion:</p>
+              <p className="text-xs text-gray-300">{issue.suggestion}</p>
+            </div>
+          )}
           {issue.path && issue.path.length > 0 && (
             <code className="px-1 py-0.5 bg-zinc-800 rounded text-xs block mt-1 text-gray-300 overflow-hidden text-ellipsis whitespace-nowrap">
               {issue.path.join('.')}
             </code>
           )}
-          {issue.range?.start?.line !== undefined && (
-            <div className="flex justify-end mt-1">
+          <div className="flex items-center justify-between gap-2 mt-1 flex-wrap">
+            {issue.range?.start?.line !== undefined && (
               <button
                 className="text-xs text-gray-300 hover:text-primary transition-colors cursor-pointer"
                 onClick={(e) => {
@@ -166,8 +177,19 @@ function IssueMarker({
               >
                 Go to line {issue.range.start.line + 1}
               </button>
-            </div>
-          )}
+            )}
+            {issue.specLink && (
+              <a
+                href={issue.specLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-blue-400 hover:text-blue-300 transition-colors underline ml-auto"
+                onClick={(e) => e.stopPropagation()}
+              >
+                See spec reference
+              </a>
+            )}
+          </div>
         </div>
       </TooltipContent>
     </Tooltip>
@@ -259,15 +281,17 @@ const IssueItem = React.memo(({
   scrollToLine,
   getValidatorColor,
   getSeverityColor,
+  onCopyIssue,
 }: { 
   issue: ValidationResult,
   scrollToLine: (lineNumber: number) => void,
   getValidatorColor: (source: string) => string,
   getSeverityColor: (severity: string) => string,
+  onCopyIssue: (issue: ValidationResult) => void,
 }) => (
   <div
     className={cn(
-      "p-2 rounded-md cursor-pointer transition-all duration-200 border overflow-hidden w-full max-w-full box-border",
+      "relative p-2 rounded-md cursor-pointer transition-all duration-200 border overflow-hidden w-full max-w-full box-border",
       "hover:shadow-md hover:translate-y-[-2px]",
       issue.code.includes("SUCCESS") 
         ? "border-green-500/20 bg-green-500/5 hover:bg-green-500/10 hover:border-green-500/30" 
@@ -280,7 +304,17 @@ const IssueItem = React.memo(({
     style={{ width: "100%", maxWidth: "540px", marginLeft: "auto", marginRight: "auto" }}
     onClick={() => issue.range?.start?.line !== undefined && scrollToLine(issue.range.start.line + 1)}
   >
-    <div className="flex flex-col gap-1 w-full max-w-full">
+    <button
+      className="absolute top-2 right-2 p-1 rounded hover:bg-background/50 transition-colors z-10"
+      onClick={(e) => {
+        e.stopPropagation();
+        onCopyIssue(issue);
+      }}
+      aria-label="Copy issue details"
+    >
+      <Copy className="h-3.5 w-3.5 text-muted-foreground hover:text-foreground" />
+    </button>
+    <div className="flex flex-col gap-1 w-full max-w-full pr-6">
       <div className="flex items-center gap-2 flex-wrap w-full max-w-full">
         <span
           className={cn(
@@ -298,17 +332,28 @@ const IssueItem = React.memo(({
         >
           {issue.code.includes("SUCCESS") ? "Success" : issue.severity}
         </span>
+        {issue.category && (
+          <span className="text-xs px-1.5 py-0.5 bg-muted rounded text-gray-300 whitespace-nowrap">
+            {issue.category}
+          </span>
+        )}
       </div>
       <p className="text-xs line-clamp-3 text-gray-300 w-full max-w-full break-words">
         {issue.message}
       </p>
+      {issue.suggestion && (
+        <div className="mt-1 p-2 bg-muted/50 rounded border-l-2 border-blue-500/50">
+          <p className="text-xs font-semibold text-blue-400 mb-0.5">Suggestion:</p>
+          <p className="text-xs text-gray-300 line-clamp-2">{issue.suggestion}</p>
+        </div>
+      )}
       {issue.path && issue.path.length > 0 && (
         <code className="px-1 py-0.5 bg-muted rounded text-xs block mt-1 opacity-80 overflow-hidden text-ellipsis whitespace-nowrap w-full max-w-full">
           {issue.path.join('.')}
         </code>
       )}
-      {issue.range?.start?.line !== undefined && (
-        <div className="flex justify-end mt-1 w-full">
+      <div className="flex items-center justify-between gap-2 mt-1 w-full flex-wrap">
+        {issue.range?.start?.line !== undefined && (
           <button
             className="text-xs text-muted-foreground hover:text-primary transition-colors cursor-pointer"
             onClick={(e) => {
@@ -318,8 +363,19 @@ const IssueItem = React.memo(({
           >
             Go to line {issue.range.start.line + 1}
           </button>
-        </div>
-      )}
+        )}
+        {issue.specLink && (
+          <a
+            href={issue.specLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-blue-400 hover:text-blue-300 transition-colors underline ml-auto"
+            onClick={(e) => e.stopPropagation()}
+          >
+            See spec reference
+          </a>
+        )}
+      </div>
     </div>
   </div>
 ));
@@ -390,7 +446,10 @@ export function VisualValidator({ isLoading, results, specContent, error, score 
             issue.message.toLowerCase().includes(searchQuery.toLowerCase()) ||
             (issue.path && issue.path.join('.').toLowerCase().includes(searchQuery.toLowerCase())) ||
             issue.source.toLowerCase().includes(searchQuery.toLowerCase()) ||
-            issue.code.toLowerCase().includes(searchQuery.toLowerCase())
+            issue.code.toLowerCase().includes(searchQuery.toLowerCase()) ||
+            (issue.errorCode && issue.errorCode.toLowerCase().includes(searchQuery.toLowerCase())) ||
+            (issue.suggestion && issue.suggestion.toLowerCase().includes(searchQuery.toLowerCase())) ||
+            (issue.category && issue.category.toLowerCase().includes(searchQuery.toLowerCase()))
         )
     );
   }, [results, enabledValidators, selectedSeverities, searchQuery]);
@@ -461,6 +520,23 @@ export function VisualValidator({ isLoading, results, specContent, error, score 
       toast.error("Download failed. See console for details.");
     }
   }, [results, filteredIssues]);
+
+  const handleCopyIssue = useCallback((issue: ValidationResult) => {
+    try {
+      const issueJson = JSON.stringify(issue, null, 2);
+      navigator.clipboard.writeText(issueJson)
+        .then(() => {
+          toast.success("Issue details copied to clipboard");
+        })
+        .catch((err) => {
+          console.error("Copy failed:", err);
+          toast.error("Failed to copy: " + (err.message || "Unknown error"));
+        });
+    } catch (err) {
+      console.error("Copy error:", err);
+      toast.error("Copy failed. See console for details.");
+    }
+  }, []);
 
   const scrollToLine = useCallback((lineNumber: number) => {
     console.log(`Attempting to scroll to line: ${lineNumber}`);
@@ -913,6 +989,7 @@ export function VisualValidator({ isLoading, results, specContent, error, score 
                       scrollToLine={scrollToLine}
                       getValidatorColor={getValidatorColor}
                       getSeverityColor={getSeverityColor}
+                      onCopyIssue={handleCopyIssue}
                     />
                   ))
                 ) : (

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,6 +12,11 @@ export interface ValidationResult {
     start: { line: number; character: number };
     end: { line: number; character: number };
   };
+  // Enhanced error properties from OAS Zod Validator v1.8.1+
+  errorCode?: string;      // e.g., "ERR_006"
+  suggestion?: string;     // Actionable fix suggestion
+  specLink?: string;        // Link to OpenAPI spec section
+  category?: string;        // e.g., "schema", "format", etc.
 }
 
 // Legacy types below (kept for backward compatibility with unused components)


### PR DESCRIPTION
Updated the version of the OAS Zod Validator to 1.8.1, and made use of the improve error handling in the UI.

Previous error detail in the UI:
<img width="557" height="104" alt="CleanShot 2026-01-16 at 16 03 50" src="https://github.com/user-attachments/assets/5cb4d8c0-2195-4dd0-954b-8385fd6a706b" />

New error detail in the UI (more actionable):
<img width="553" height="201" alt="CleanShot 2026-01-16 at 16 03 58" src="https://github.com/user-attachments/assets/36afe122-ad51-471f-94be-e9473c9671fc" />
